### PR TITLE
fix: Retrieve title from content

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -211,8 +211,8 @@ export default class HoarderPlugin extends Plugin {
     // Try content based on type
     if (bookmark.content.type === "link") {
       // For links, try content title, then URL
-      if (bookmark.title) {
-        return bookmark.title;
+      if (bookmark.content.title) {
+        return bookmark.content.title;
       }
       if (bookmark.content.url) {
         try {


### PR DESCRIPTION
Hello,
I noticed that the title was missing on bookmarks created from the [chrome extension](https://chromewebstore.google.com/detail/karakeep/kgcjekpmcjjogibpjebkhaanilehneje), which sets the title in the content and not in the bookmarks directly.
This should fix it.