### PR TITLE
fix: skip dirty titles from platforms that use body text as HTML title

### DIFF
--- a/src/bookmark-utils.test.ts
+++ b/src/bookmark-utils.test.ts
@@ -325,4 +325,109 @@ describe("getBookmarkTitle", () => {
       expect(getBookmarkTitle(bookmark)).toBe("- [ ] Buy groceries");
     });
   });
+
+  describe("dirty title detection", () => {
+    it("should use content.title when it is a normal short title", () => {
+      const bookmark = {
+        ...baseBookmark,
+        content: {
+          type: "link" as const,
+          url: "https://mp.weixin.qq.com/s/abc123",
+          title: "为什么 OpenClaw 火了？",
+        },
+      } as HoarderBookmark;
+      expect(getBookmarkTitle(bookmark)).toBe("为什么 OpenClaw 火了？");
+    });
+
+    it("should fall back to URL when content.title exceeds 80 characters", () => {
+      const dirtyTitle =
+        "openClaw 为什么火以及他对软件领域最大的意义在哪呢？\n其实2年前就有 openClaw 这类 Agent，只是没火。为什么是 openClaw 火了呢？";
+      const bookmark = {
+        ...baseBookmark,
+        content: {
+          type: "link" as const,
+          url: "https://mp.weixin.qq.com/s/MBhALMlL6MlUnOHlqlNtHQ",
+          title: dirtyTitle,
+        },
+      } as HoarderBookmark;
+      // Should fall back to URL path, not return the body text as title
+      const result = getBookmarkTitle(bookmark);
+      expect(result).not.toBe(dirtyTitle);
+      expect(result.length).toBeLessThan(dirtyTitle.length);
+    });
+
+    it("should fall back to URL when content.title contains multiple sentences", () => {
+      const bookmark = {
+        ...baseBookmark,
+        content: {
+          type: "link" as const,
+          url: "https://example.com/article",
+          title: "第一句话。第二句话。第三句话。",
+        },
+      } as HoarderBookmark;
+      expect(getBookmarkTitle(bookmark)).toBe("article");
+    });
+
+    it("should keep a title with exactly one sentence-ending punctuation mark", () => {
+      const bookmark = {
+        ...baseBookmark,
+        content: {
+          type: "link" as const,
+          url: "https://example.com/article",
+          title: "这篇文章改变了我对 AI 的看法！",
+        },
+      } as HoarderBookmark;
+      expect(getBookmarkTitle(bookmark)).toBe("这篇文章改变了我对 AI 的看法！");
+    });
+
+    it("should fall back to URL when content.title contains multiple English sentences", () => {
+      const bookmark = {
+        ...baseBookmark,
+        content: {
+          type: "link" as const,
+          url: "https://example.com/article",
+          title: "This is the first sentence. This is the second sentence. And a third one.",
+        },
+      } as HoarderBookmark;
+      expect(getBookmarkTitle(bookmark)).toBe("article");
+    });
+
+    it("should keep a title with exactly one English sentence-ending punctuation mark", () => {
+      const bookmark = {
+        ...baseBookmark,
+        content: {
+          type: "link" as const,
+          url: "https://example.com/article",
+          title: "Why did OpenClaw blow up?",
+        },
+      } as HoarderBookmark;
+      expect(getBookmarkTitle(bookmark)).toBe("Why did OpenClaw blow up?");
+    });
+
+    it("should keep a title with exactly 80 characters", () => {
+      const title = "a".repeat(80);
+      const bookmark = {
+        ...baseBookmark,
+        content: {
+          type: "link" as const,
+          url: "https://example.com/article",
+          title,
+        },
+      } as HoarderBookmark;
+      expect(getBookmarkTitle(bookmark)).toBe(title);
+    });
+
+    it("should treat a title with 81 characters as dirty and fall back to URL", () => {
+      const title = "a".repeat(81);
+      const bookmark = {
+        ...baseBookmark,
+        content: {
+          type: "link" as const,
+          url: "https://example.com/article",
+          title,
+        },
+      } as HoarderBookmark;
+      expect(getBookmarkTitle(bookmark)).toBe("article");
+    });
+  });
 });

--- a/src/bookmark-utils.ts
+++ b/src/bookmark-utils.ts
@@ -14,9 +14,14 @@ import { HoarderBookmark } from "./hoarder-client";
  */
 function isDirtyTitle(title: string): boolean {
   if (title.length > 80) return true;
-  // Count sentence-ending punctuation marks
-  const sentenceEnders = title.match(/[。！？!?]/g);
-  return sentenceEnders !== null && sentenceEnders.length > 1;
+  // Count sentence-ending punctuation marks (Chinese and English)
+  // For English periods, only count ". " followed by an uppercase letter to avoid
+  // false positives from version numbers (v1.2.3) or domains (example.com)
+  const chineseSentenceEnders = title.match(/[。！？]/g);
+  const englishSentenceEnders = title.match(/[!?]|(?<=\. )[A-Z]/g);
+  const total =
+    (chineseSentenceEnders?.length ?? 0) + (englishSentenceEnders?.length ?? 0);
+  return total > 1;
 }
 
 /**


### PR DESCRIPTION
## Problem

Some platforms (notably WeChat Official Accounts) allow publishing articles without an explicit title. In these cases, the platform fills the HTML `<title>` tag with the first paragraph of the article body. Karakeep faithfully stores this as the bookmark title, which then gets written into Obsidian note filenames and frontmatter — resulting in notes with extremely long, unreadable titles containing full article text.

## Solution

Add an `isDirtyTitle()` helper that detects body-text-as-title using two heuristics:

1. Title length exceeds 80 characters
2. Title contains more than one sentence-ending punctuation mark (`。！？!?`)

When a dirty title is detected, `getBookmarkTitle()` skips `content.title` and falls back to URL-based title extraction instead.

## Example

**Before:** Note title = `openClaw 为什么火以及他对软件领域最大的意义在哪呢？\n其实2年前就有 openClaw 这类 Agent，只是没火。为什么是 openClaw 火了呢？...` (400+ characters)

**After:** Note title = hostname or path extracted from the article URL

## Notes

- No behavior change for normal titles (≤ 80 chars, single sentence)
- The heuristic handles both Chinese and English punctuation
- This is a best-effort fix; the ideal solution would be a platform-specific scraper that reads the real title from the DOM (e.g. `#activity-name` for WeChat), but that requires changes in Karakeep rather than this plugin