### PR TITLE
Fixed existing archived bookmarks continuously  appending '-1' to file name

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -281,6 +281,11 @@ export default class HoarderPlugin extends Plugin {
       throw new Error("Archive folder not configured");
     }
 
+    // Already in the archive folder, nothing to do
+    if (file.path.startsWith(`${archiveFolder}/`)) {
+      return;
+    }
+
     // Create archive folder if it doesn't exist
     if (!(await this.app.vault.adapter.exists(archiveFolder))) {
       await this.app.vault.createFolder(archiveFolder);


### PR DESCRIPTION
Fixes #38 

Added an early return in moveToArchiveFolder if file already exists in archiveFolder.

Naive approach, works and solves the bug in testing.

Notes:
- All archived notes from the Karakeep side are still 'processed' (as noted in the Sync Message) on each sync
  - As in every single archived note will run through the handleDeletedAndArchivedBookmarks logic, and then in this case the moveToArchiveFolder logic (up to the new early return)
  - The overhead for this is very small, and is technically happening in main right now anyways, I just noted we have logic that skips unmodified normal saves and notes that in the sync message (skippedFiles)
- I think in the short term this is still a worthwhile change to have, just as a stopgap as well as some added safety in the moveToArchiveFolder method. But a long term fix will likely involve some slight rethinking of the syncBookmarks/handleDeletedAndArchivedBookmarks logic, only if we want to avoid unneeded processing and improve the sync message


I would be down to collaborate on a larger-scale fix if desired, but was just unsure about how much of the sync logic you'd be willing to modify, or what the best way to handle it would be. This current fix works and logically archived notes work exactly how they currently do anyways.