### PR TITLE
Fixed existing archived bookmarks reprocessing every sync

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -257,6 +257,9 @@ export default class HoarderPlugin extends Plugin {
               instruction.reason === "deleted"
                 ? this.settings.archiveFolder
                 : this.settings.archivedBookmarkFolder;
+            if (instruction.reason === "archived" && file.path.startsWith(`${archiveFolder}/`)) {
+              break;
+            }
             await this.moveToArchiveFolder(file, archiveFolder);
             break;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,6 +281,11 @@ export default class HoarderPlugin extends Plugin {
       throw new Error("Archive folder not configured");
     }
 
+    // Already in the archive folder, nothing to do
+    if (file.path.startsWith(`${archiveFolder}/`)) {
+      return;
+    }
+
     // Create archive folder if it doesn't exist
     if (!(await this.app.vault.adapter.exists(archiveFolder))) {
       await this.app.vault.createFolder(archiveFolder);


### PR DESCRIPTION
## Summary

- Fixes #38 
- Stops already archived notes from being reprocessed every sync

## Changes

- Added logic to skip file on archive case in `handleDeletedAndArchivedBookmarks` if file already exists in `archiveFolder`.
- Added an early return in `moveToArchiveFolder` if file already exists in `archiveFolder` (safety).

## How it Works

- When archive actions are enabled, the plugin fetches all bookmarks from Karakeep including archived ones
- Previously, any bookmark marked as archived would be processed by `moveToArchiveFolder` on every sync, causing naming conflicts each time
- Now there is a early check in the `archive` case in `handleDeletedAndArchivedBookmarks`. Before calling moveToArchiveFolder, it checks whether the file's current path already starts with the configured archive folder path
  - If it does it skips processing for that file, if it does not it proceeds as normal
- The same check is also added to `moveToArchiveFolder`, likely will not hit under current circumstances, but added for safety as that was where the original issue stemmed from

## Testing

- Build passes successfully
- Tests pass successfully
- Acts as expected during user testing

## Notes

- Originally was looking to detect and track existing (thus unchanged) archived files, keep track of them in the sync message, etc. But decided adding the check for existing files to the switch case is cleaner, and prevents further processing, as archived files don't appear to be able to sync further changes anyways.
- Renaming logic will still run properly on notes that happen to share the same filename that both get archived together


Fixes #38
Supersedes #39 