### PR TITLE
2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,19 @@
       "name": "obsidian-hoarder",
       "version": "1.12.0",
       "license": "MIT",
+      "dependencies": {
+        "eta": "^4.5.1"
+      },
       "devDependencies": {
-        "@trivago/prettier-plugin-sort-imports": "^5",
+        "@trivago/prettier-plugin-sort-imports": "^6",
         "@types/jest": "^30",
-        "@types/node": "^22",
+        "@types/node": "^25",
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
         "builtin-modules": "^5",
-        "esbuild": "^0.25",
+        "esbuild": "^0.27",
         "jest": "^30",
-        "obsidian": "^1.10",
+        "obsidian": "^1.12",
         "prettier": "^3",
         "prompt-sync": "^4",
         "ts-jest": "^29",
@@ -553,9 +556,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.38.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.1.tgz",
-      "integrity": "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==",
+      "version": "6.38.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+      "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -601,9 +604,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
       "cpu": [
         "ppc64"
       ],
@@ -618,9 +621,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
       "cpu": [
         "arm"
       ],
@@ -635,9 +638,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
       "cpu": [
         "arm64"
       ],
@@ -652,9 +655,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
       "cpu": [
         "x64"
       ],
@@ -669,9 +672,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
       "cpu": [
         "arm64"
       ],
@@ -686,9 +689,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
       "cpu": [
         "x64"
       ],
@@ -703,9 +706,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
       "cpu": [
         "arm64"
       ],
@@ -720,9 +723,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
       "cpu": [
         "x64"
       ],
@@ -737,9 +740,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
       "cpu": [
         "arm"
       ],
@@ -754,9 +757,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
       "cpu": [
         "arm64"
       ],
@@ -771,9 +774,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
       "cpu": [
         "ia32"
       ],
@@ -788,9 +791,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
       "cpu": [
         "loong64"
       ],
@@ -805,9 +808,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
       "cpu": [
         "mips64el"
       ],
@@ -822,9 +825,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
       "cpu": [
         "ppc64"
       ],
@@ -839,9 +842,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
       "cpu": [
         "riscv64"
       ],
@@ -856,9 +859,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
       "cpu": [
         "s390x"
       ],
@@ -873,9 +876,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
       "cpu": [
         "x64"
       ],
@@ -890,9 +893,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
       "cpu": [
         "arm64"
       ],
@@ -907,9 +910,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
       "cpu": [
         "x64"
       ],
@@ -924,9 +927,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
       "cpu": [
         "arm64"
       ],
@@ -941,9 +944,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
       "cpu": [
         "x64"
       ],
@@ -958,9 +961,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
       "cpu": [
         "arm64"
       ],
@@ -975,9 +978,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
       "cpu": [
         "x64"
       ],
@@ -992,9 +995,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
       "cpu": [
         "arm64"
       ],
@@ -1009,9 +1012,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
       "cpu": [
         "ia32"
       ],
@@ -1026,9 +1029,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
       "cpu": [
         "x64"
       ],
@@ -1088,9 +1091,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1167,9 +1170,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1937,30 +1940,36 @@
       }
     },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-5.2.2.tgz",
-      "integrity": "sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-6.0.2.tgz",
+      "integrity": "sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/generator": "^7.26.5",
-        "@babel/parser": "^7.26.7",
-        "@babel/traverse": "^7.26.7",
-        "@babel/types": "^7.26.7",
+        "@babel/generator": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
         "javascript-natural-sort": "^0.7.1",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21",
+        "minimatch": "^9.0.0",
+        "parse-imports-exports": "^0.2.4"
       },
       "engines": {
-        "node": ">18.12"
+        "node": ">= 20"
       },
       "peerDependencies": {
         "@vue/compiler-sfc": "3.x",
         "prettier": "2.x - 3.x",
+        "prettier-plugin-ember-template-tag": ">= 2.0.0",
         "prettier-plugin-svelte": "3.x",
         "svelte": "4.x || 5.x"
       },
       "peerDependenciesMeta": {
         "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "prettier-plugin-ember-template-tag": {
           "optional": true
         },
         "prettier-plugin-svelte": {
@@ -2091,13 +2100,13 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "22.18.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.13.tgz",
-      "integrity": "sha512-Bo45YKIjnmFtv6I1TuC8AaHBbqXtIo+Om5fE4QiU1Tj8QR/qt+8O3BAtOimG5IFmwaWiPmB3Mv3jtYzBA4Us2A==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -2164,6 +2173,191 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.2.tgz",
+      "integrity": "sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/typescript-estree": "8.46.2",
+        "@typescript-eslint/utils": "8.46.2",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
+      "integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.46.2",
+        "@typescript-eslint/tsconfig-utils": "8.46.2",
+        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/visitor-keys": "8.46.2",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
+      "integrity": "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.46.2",
+        "@typescript-eslint/types": "^8.46.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
+      "integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.2.tgz",
+      "integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.46.2",
+        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/typescript-estree": "8.46.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
+      "integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.46.2",
+        "@typescript-eslint/tsconfig-utils": "8.46.2",
+        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/visitor-keys": "8.46.2",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
+      "integrity": "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.46.2",
+        "@typescript-eslint/types": "^8.46.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
+      "integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.46.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
@@ -2189,7 +2383,36 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/project-service": {
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
+      "integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.46.2",
+        "@typescript-eslint/tsconfig-utils": "8.46.2",
+        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/visitor-keys": "8.46.2",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
       "version": "8.46.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
       "integrity": "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==",
@@ -2200,6 +2423,23 @@
         "@typescript-eslint/types": "^8.46.2",
         "debug": "^4.3.4"
       },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
+      "integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2229,48 +2469,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
-      "integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.2.tgz",
-      "integrity": "sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2",
-        "@typescript-eslint/utils": "8.46.2",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/types": {
       "version": "8.46.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
@@ -2283,59 +2481,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
-      "integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.46.2",
-        "@typescript-eslint/tsconfig-utils": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.2.tgz",
-      "integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -2671,9 +2816,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2872,9 +3017,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3321,9 +3466,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3334,32 +3479,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
       }
     },
     "node_modules/escalade": {
@@ -3479,9 +3624,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3626,6 +3771,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eta": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.1.tgz",
+      "integrity": "sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/bgub/eta?sponsor=1"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3739,9 +3896,9 @@
       "peer": true
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3819,9 +3976,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -3973,9 +4130,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4769,9 +4926,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5003,10 +5160,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
+    "node_modules/lodash-es": {
       "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5230,9 +5387,9 @@
       }
     },
     "node_modules/obsidian": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.10.2.tgz",
-      "integrity": "sha512-bX03YCHf06OTzI/D+QK71ajCPCmwr/cjxzlVXjQa10DjK5iHRWhtJJpp83arSCyayFMp23u+UHcY7hxcEx2Mvg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+      "integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5241,7 +5398,7 @@
       },
       "peerDependencies": {
         "@codemirror/state": "6.5.0",
-        "@codemirror/view": "6.38.1"
+        "@codemirror/view": "6.38.6"
       }
     },
     "node_modules/once": {
@@ -5353,6 +5510,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5371,6 +5538,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5434,9 +5608,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6085,9 +6259,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6302,9 +6476,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -16,25 +16,29 @@
   },
   "keywords": [
     "obsidian",
+    "karakeep",
     "hoarder",
     "bookmarks"
   ],
   "author": "Jordan Hofker <jhofker@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@trivago/prettier-plugin-sort-imports": "^5",
+    "@trivago/prettier-plugin-sort-imports": "^6",
     "@types/jest": "^30",
-    "@types/node": "^22",
+    "@types/node": "^25",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "builtin-modules": "^5",
-    "esbuild": "^0.25",
+    "esbuild": "^0.27",
     "jest": "^30",
-    "obsidian": "^1.10",
+    "obsidian": "^1.12",
     "prettier": "^3",
     "prompt-sync": "^4",
     "ts-jest": "^29",
     "tslib": "^2",
     "typescript": "^5"
+  },
+  "dependencies": {
+    "eta": "^4.5.1"
   }
 }

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -1,10 +1,42 @@
 export const requestUrl = jest.fn();
 export class App {}
 export class TFile {}
+export class TFolder {}
 export class Plugin {}
+export class PluginSettingTab {}
 export class Events {
   trigger = jest.fn();
 }
 export class Notice {
   constructor(_message: string) {}
+}
+export class Setting {
+  constructor(_el: any) {}
+  setName() {
+    return this;
+  }
+  setDesc() {
+    return this;
+  }
+  addText() {
+    return this;
+  }
+  addToggle() {
+    return this;
+  }
+  addButton() {
+    return this;
+  }
+  addDropdown() {
+    return this;
+  }
+}
+export class AbstractInputSuggest<T> {
+  constructor(_app: any, _inputEl: any) {}
+  getSuggestions(_input: string): T[] {
+    return [];
+  }
+  renderSuggestion(_item: T, _el: any) {}
+  selectSuggestion(_item: T) {}
+  close() {}
 }

--- a/src/asset-handler.test.ts
+++ b/src/asset-handler.test.ts
@@ -1,4 +1,86 @@
-import { sanitizeAssetFileName } from "./asset-handler";
+import {
+  isImageExtension,
+  processBookmarkAssets,
+  resolveAssetExtension,
+  sanitizeAssetFileName,
+} from "./asset-handler";
+import { HoarderBookmark } from "./hoarder-client";
+import { DEFAULT_SETTINGS, HoarderSettings } from "./settings";
+
+// Helper to build a minimal mock App with vault adapter
+function createMockApp(existingFiles: string[] = []) {
+  const writtenFiles: { path: string; data: ArrayBuffer }[] = [];
+  const removedFiles: string[] = [];
+  const createdFolders: string[] = [];
+
+  return {
+    app: {
+      vault: {
+        adapter: {
+          exists: jest.fn(async (path: string) => {
+            // Check if it's a folder that was created or the attachments folder with files
+            return createdFolders.includes(path) || existingFiles.some((f) => f.startsWith(path));
+          }),
+          list: jest.fn(async (_path: string) => ({
+            files: existingFiles,
+            folders: [],
+          })),
+          writeBinary: jest.fn(async (path: string, data: ArrayBuffer) => {
+            writtenFiles.push({ path, data });
+          }),
+          remove: jest.fn(async (path: string) => {
+            removedFiles.push(path);
+          }),
+        },
+        createFolder: jest.fn(async (path: string) => {
+          createdFolders.push(path);
+        }),
+      },
+    } as any,
+    writtenFiles,
+    removedFiles,
+    createdFolders,
+  };
+}
+
+function createMockClient(contentType: string = "image/jpeg") {
+  return {
+    downloadAsset: jest.fn(async (_assetId: string) => ({
+      buffer: new ArrayBuffer(8),
+      contentType,
+    })),
+    getAssetUrl: jest.fn((assetId: string) => `https://karakeep.example.com/assets/${assetId}`),
+  } as any;
+}
+
+function createBookmark(overrides: Partial<HoarderBookmark> = {}): HoarderBookmark {
+  return {
+    id: "bm-1",
+    createdAt: "2024-01-01T00:00:00Z",
+    modifiedAt: null,
+    archived: false,
+    favourited: false,
+    taggingStatus: null,
+    tags: [],
+    assets: [],
+    content: {
+      type: "link",
+      url: "https://example.com/article",
+      imageAssetId: "img-asset-1",
+    },
+    ...overrides,
+  };
+}
+
+function createSettings(overrides: Partial<HoarderSettings> = {}): HoarderSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    apiEndpoint: "https://karakeep.example.com/api/v1",
+    attachmentsFolder: "Hoarder/attachments",
+    downloadAssets: true,
+    ...overrides,
+  };
+}
 
 describe("sanitizeAssetFileName", () => {
   describe("invalid character replacement", () => {
@@ -111,6 +193,491 @@ describe("sanitizeAssetFileName", () => {
 
     it("should handle normal alphanumeric titles unchanged", () => {
       expect(sanitizeAssetFileName("MyPhoto123")).toBe("MyPhoto123");
+    });
+
+    it("should strip periods to avoid fake extensions", () => {
+      expect(sanitizeAssetFileName("Keeper.sh-Calendar-Syncing,")).toBe("Keeper-sh-Calendar-Syncing");
+    });
+
+    it("should strip commas, semicolons, and other punctuation", () => {
+      expect(sanitizeAssetFileName("hello, world; foo & bar")).toBe("hello-world-foo-bar");
+    });
+
+    it("should strip parentheses and brackets", () => {
+      expect(sanitizeAssetFileName("article (draft) [v2]")).toBe("article-draft-v2");
+    });
+
+    it("should strip hash and at signs", () => {
+      expect(sanitizeAssetFileName("issue #42 @user")).toBe("issue-42-user");
+    });
+  });
+});
+
+describe("resolveAssetExtension", () => {
+  describe("Content-Type header detection", () => {
+    it("should detect JPEG from content-type", () => {
+      expect(resolveAssetExtension("image/jpeg", "Banner Image", "")).toBe("jpg");
+    });
+
+    it("should detect PNG from content-type", () => {
+      expect(resolveAssetExtension("image/png", "Screenshot", "")).toBe("png");
+    });
+
+    it("should detect PDF from content-type", () => {
+      expect(resolveAssetExtension("application/pdf", "Unknown", "")).toBe("pdf");
+    });
+
+    it("should detect HTML from content-type", () => {
+      expect(resolveAssetExtension("text/html", "Full Page Archive", "")).toBe("html");
+    });
+
+    it("should detect MHTML from content-type", () => {
+      expect(resolveAssetExtension("multipart/related", "Full Page Archive", "")).toBe("mhtml");
+    });
+
+    it("should strip charset from content-type", () => {
+      expect(resolveAssetExtension("text/html; charset=utf-8", "Archive", "")).toBe("html");
+    });
+
+    it("should detect WebP from content-type", () => {
+      expect(resolveAssetExtension("image/webp", "Banner Image", "")).toBe("webp");
+    });
+  });
+
+  describe("asset label fallback", () => {
+    it("should return pdf for PDF labels", () => {
+      expect(resolveAssetExtension(null, "PDF Archive", "")).toBe("pdf");
+    });
+
+    it("should return mhtml for Full Page Archive labels", () => {
+      expect(resolveAssetExtension(null, "Full Page Archive", "")).toBe("mhtml");
+    });
+
+    it("should return png for Screenshot labels", () => {
+      expect(resolveAssetExtension(null, "Screenshot", "")).toBe("png");
+    });
+  });
+
+  describe("URL extension fallback", () => {
+    it("should detect png from URL", () => {
+      expect(resolveAssetExtension(null, "Additional Image", "https://example.com/img.png")).toBe(
+        "png"
+      );
+    });
+
+    it("should detect pdf from URL", () => {
+      expect(resolveAssetExtension(null, "Unknown", "https://example.com/doc.pdf")).toBe("pdf");
+    });
+
+    it("should ignore query strings in URL", () => {
+      expect(
+        resolveAssetExtension(null, "Additional Image", "https://example.com/img.png?w=100")
+      ).toBe("png");
+    });
+
+    it("should ignore unsupported extensions", () => {
+      expect(resolveAssetExtension(null, "Unknown", "https://example.com/assets/abc123")).toBe(
+        "jpg"
+      );
+    });
+  });
+
+  describe("default fallback", () => {
+    it("should default to jpg when nothing matches", () => {
+      expect(resolveAssetExtension(null, "Unknown", "")).toBe("jpg");
+    });
+
+    it("should default to jpg for Karakeep asset URLs with no extension", () => {
+      expect(
+        resolveAssetExtension(null, "Additional Image", "https://karakeep.example.com/assets/abc")
+      ).toBe("jpg");
+    });
+  });
+
+  describe("priority order", () => {
+    it("should prefer content-type over label", () => {
+      // Content-type says PNG, label says Screenshot (which maps to PNG anyway)
+      expect(resolveAssetExtension("image/jpeg", "Screenshot", "")).toBe("jpg");
+    });
+
+    it("should prefer content-type over URL extension", () => {
+      expect(
+        resolveAssetExtension("application/pdf", "Unknown", "https://example.com/file.jpg")
+      ).toBe("pdf");
+    });
+  });
+});
+
+describe("isImageExtension", () => {
+  it("should return true for image extensions", () => {
+    expect(isImageExtension("jpg")).toBe(true);
+    expect(isImageExtension("jpeg")).toBe(true);
+    expect(isImageExtension("png")).toBe(true);
+    expect(isImageExtension("gif")).toBe(true);
+    expect(isImageExtension("webp")).toBe(true);
+    expect(isImageExtension("svg")).toBe(true);
+  });
+
+  it("should return false for non-image extensions", () => {
+    expect(isImageExtension("pdf")).toBe(false);
+    expect(isImageExtension("html")).toBe(false);
+    expect(isImageExtension("mhtml")).toBe(false);
+  });
+
+  it("should be case-insensitive", () => {
+    expect(isImageExtension("JPG")).toBe(true);
+    expect(isImageExtension("PNG")).toBe(true);
+    expect(isImageExtension("PDF")).toBe(false);
+  });
+});
+
+describe("processBookmarkAssets", () => {
+  describe("correct extension detection", () => {
+    it("should save a banner image with correct extension from content-type", async () => {
+      const { app, writtenFiles } = createMockApp();
+      const client = createMockClient("image/png");
+      const bookmark = createBookmark();
+      const settings = createSettings();
+
+      await processBookmarkAssets(app, bookmark, "Test Article", client, settings);
+
+      expect(writtenFiles.length).toBe(1);
+      expect(writtenFiles[0].path).toMatch(/\.png$/);
+    });
+
+    it("should save a PDF asset with .pdf extension", async () => {
+      const { app, writtenFiles } = createMockApp();
+      const client = createMockClient("application/pdf");
+      const bookmark = createBookmark({
+        content: {
+          type: "asset",
+          assetType: "pdf",
+          assetId: "pdf-asset-1",
+        },
+      });
+      const settings = createSettings();
+
+      await processBookmarkAssets(app, bookmark, "My Document", client, settings);
+
+      expect(writtenFiles.length).toBe(1);
+      expect(writtenFiles[0].path).toMatch(/\.pdf$/);
+    });
+
+    it("should save a full page archive with .mhtml extension", async () => {
+      const { app, writtenFiles } = createMockApp();
+      const client = createMockClient("multipart/related");
+      const bookmark = createBookmark({
+        content: {
+          type: "link",
+          url: "https://example.com",
+          fullPageArchiveAssetId: "archive-1",
+        },
+      });
+      const settings = createSettings({ downloadFullPageArchives: true });
+
+      await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(writtenFiles.length).toBe(1);
+      expect(writtenFiles[0].path).toMatch(/\.mhtml$/);
+    });
+
+    it("should save a screenshot with extension from content-type", async () => {
+      const { app, writtenFiles } = createMockApp();
+      const client = createMockClient("image/png");
+      const bookmark = createBookmark({
+        content: {
+          type: "link",
+          url: "https://example.com",
+          screenshotAssetId: "screenshot-1",
+        },
+      });
+      const settings = createSettings();
+
+      await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(writtenFiles.length).toBe(1);
+      expect(writtenFiles[0].path).toMatch(/\.png$/);
+    });
+  });
+
+  describe("cleanup of broken files", () => {
+    it("should replace a PDF saved as .jpg with correct .pdf file", async () => {
+      const { app, writtenFiles, removedFiles } = createMockApp([
+        "Hoarder/attachments/pdf-asset-1-My-Document.jpg",
+      ]);
+      const client = createMockClient("application/pdf");
+      const bookmark = createBookmark({
+        content: {
+          type: "asset",
+          assetType: "pdf",
+          assetId: "pdf-asset-1",
+        },
+      });
+      const settings = createSettings();
+
+      await processBookmarkAssets(app, bookmark, "My Document", client, settings);
+
+      // Should have written the new .pdf file
+      expect(writtenFiles.length).toBe(1);
+      expect(writtenFiles[0].path).toMatch(/\.pdf$/);
+
+      // Should have removed the old .jpg file
+      expect(removedFiles).toContain("Hoarder/attachments/pdf-asset-1-My-Document.jpg");
+    });
+
+    it("should replace an MHTML archive saved as .jpg with correct .mhtml file", async () => {
+      const { app, writtenFiles, removedFiles } = createMockApp([
+        "Hoarder/attachments/archive-1-Article-Full-Page-Archive.jpg",
+      ]);
+      const client = createMockClient("multipart/related");
+      const bookmark = createBookmark({
+        content: {
+          type: "link",
+          url: "https://example.com",
+          fullPageArchiveAssetId: "archive-1",
+        },
+      });
+      const settings = createSettings({ downloadFullPageArchives: true });
+
+      await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(writtenFiles.length).toBe(1);
+      expect(writtenFiles[0].path).toMatch(/\.mhtml$/);
+      expect(removedFiles).toContain("Hoarder/attachments/archive-1-Article-Full-Page-Archive.jpg");
+    });
+
+    it("should NOT re-download an image that already has a correct image extension", async () => {
+      const { app, writtenFiles } = createMockApp([
+        "Hoarder/attachments/img-asset-1-Test-Article-Banner-Image.png",
+      ]);
+      const client = createMockClient("image/png");
+      const bookmark = createBookmark();
+      const settings = createSettings();
+
+      await processBookmarkAssets(app, bookmark, "Test Article", client, settings);
+
+      // Should not have downloaded or written anything
+      expect(writtenFiles.length).toBe(0);
+      expect(client.downloadAsset).not.toHaveBeenCalled();
+    });
+
+    it("should NOT re-download a PDF that already has .pdf extension", async () => {
+      const { app, writtenFiles } = createMockApp([
+        "Hoarder/attachments/pdf-asset-1-My-Document.pdf",
+      ]);
+      const client = createMockClient("application/pdf");
+      const bookmark = createBookmark({
+        content: {
+          type: "asset",
+          assetType: "pdf",
+          assetId: "pdf-asset-1",
+        },
+      });
+      const settings = createSettings();
+
+      await processBookmarkAssets(app, bookmark, "My Document", client, settings);
+
+      expect(writtenFiles.length).toBe(0);
+      expect(client.downloadAsset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("embed syntax", () => {
+    it("should use ![[]] syntax for PDFs", async () => {
+      const { app } = createMockApp();
+      const client = createMockClient("application/pdf");
+      const bookmark = createBookmark({
+        content: {
+          type: "asset",
+          assetType: "pdf",
+          assetId: "pdf-asset-1",
+        },
+      });
+      const settings = createSettings();
+
+      const result = await processBookmarkAssets(app, bookmark, "Doc", client, settings);
+
+      expect(result.content).toMatch(/!\[\[.*\.pdf\]\]/);
+    });
+
+    it("should use []() link syntax for HTML archives", async () => {
+      const { app } = createMockApp();
+      const client = createMockClient("text/html");
+      const bookmark = createBookmark({
+        content: {
+          type: "link",
+          url: "https://example.com",
+          fullPageArchiveAssetId: "archive-1",
+        },
+      });
+      const settings = createSettings({ downloadFullPageArchives: true });
+
+      const result = await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      // Should be a link, not an image embed
+      expect(result.content).toMatch(/\[Article - Full Page Archive\]/);
+      expect(result.content).not.toMatch(/!\[/);
+    });
+
+    it("should use ![]() syntax for images", async () => {
+      const { app } = createMockApp();
+      const client = createMockClient("image/jpeg");
+      const bookmark = createBookmark();
+      const settings = createSettings();
+
+      const result = await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(result.content).toMatch(/!\[Article - Banner Image\]/);
+    });
+  });
+
+  describe("per-type download toggles", () => {
+    it("should skip banner images when downloadBannerImages is false", async () => {
+      const { app, writtenFiles } = createMockApp();
+      const client = createMockClient("image/jpeg");
+      const bookmark = createBookmark();
+      const settings = createSettings({ downloadBannerImages: false });
+
+      const result = await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(writtenFiles.length).toBe(0);
+      // Should fall back to remote URL embed
+      expect(result.content).toContain("karakeep.example.com/assets/img-asset-1");
+    });
+
+    it("should skip screenshots when downloadScreenshots is false", async () => {
+      const { app, writtenFiles } = createMockApp();
+      const client = createMockClient("image/png");
+      const bookmark = createBookmark({
+        content: {
+          type: "link",
+          url: "https://example.com",
+          screenshotAssetId: "screenshot-1",
+        },
+      });
+      const settings = createSettings({ downloadScreenshots: false });
+
+      await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(writtenFiles.length).toBe(0);
+    });
+
+    it("should skip PDF archives when downloadPdfArchives is false", async () => {
+      const { app, writtenFiles } = createMockApp();
+      const client = createMockClient("application/pdf");
+      const bookmark = createBookmark({
+        content: {
+          type: "asset",
+          assetType: "pdf",
+          assetId: "pdf-asset-1",
+        },
+      });
+      const settings = createSettings({ downloadPdfArchives: false });
+
+      const result = await processBookmarkAssets(app, bookmark, "Doc", client, settings);
+
+      expect(writtenFiles.length).toBe(0);
+      // Should link to remote URL instead
+      expect(result.content).toContain("karakeep.example.com/assets/pdf-asset-1");
+    });
+
+    it("should skip full page archives when downloadFullPageArchives is false", async () => {
+      const { app, writtenFiles } = createMockApp();
+      const client = createMockClient("multipart/related");
+      const bookmark = createBookmark({
+        content: {
+          type: "link",
+          url: "https://example.com",
+          fullPageArchiveAssetId: "archive-1",
+        },
+      });
+      const settings = createSettings({ downloadFullPageArchives: false });
+
+      await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(writtenFiles.length).toBe(0);
+    });
+
+    it("should skip all downloads when downloadAssets is false", async () => {
+      const { app, writtenFiles } = createMockApp();
+      const client = createMockClient("image/jpeg");
+      const bookmark = createBookmark({
+        content: {
+          type: "link",
+          url: "https://example.com",
+          imageAssetId: "img-1",
+          screenshotAssetId: "ss-1",
+          fullPageArchiveAssetId: "arch-1",
+        },
+      });
+      const settings = createSettings({ downloadAssets: false });
+
+      await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(writtenFiles.length).toBe(0);
+    });
+  });
+
+  describe("frontmatter", () => {
+    it("should include pdf_archive in frontmatter for PDF assets", async () => {
+      const { app } = createMockApp();
+      const client = createMockClient("application/pdf");
+      const bookmark = createBookmark({
+        content: {
+          type: "asset",
+          assetType: "pdf",
+          assetId: "pdf-asset-1",
+        },
+      });
+      const settings = createSettings();
+
+      const result = await processBookmarkAssets(app, bookmark, "Doc", client, settings);
+
+      expect(result.frontmatter?.pdf_archive).toMatch(/^\"\[\[.*\.pdf\]\]\"$/);
+    });
+
+    it("should include banner in frontmatter for image assets", async () => {
+      const { app } = createMockApp();
+      const client = createMockClient("image/jpeg");
+      const bookmark = createBookmark();
+      const settings = createSettings();
+
+      const result = await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(result.frontmatter?.banner).toMatch(/^\"\[\[.*\.jpg\]\]\"$/);
+    });
+
+    it("should include full_page_archive in frontmatter", async () => {
+      const { app } = createMockApp();
+      const client = createMockClient("multipart/related");
+      const bookmark = createBookmark({
+        content: {
+          type: "link",
+          url: "https://example.com",
+          fullPageArchiveAssetId: "archive-1",
+        },
+      });
+      const settings = createSettings({ downloadFullPageArchives: true });
+
+      const result = await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(result.frontmatter?.full_page_archive).toMatch(/^\"\[\[.*\.mhtml\]\]\"$/);
+    });
+  });
+
+  describe("linkHtmlContent skipping", () => {
+    it("should skip assets with assetType linkHtmlContent", async () => {
+      const { app, writtenFiles } = createMockApp();
+      const client = createMockClient("text/html");
+      const bookmark = createBookmark({
+        content: { type: "link", url: "https://example.com" },
+        assets: [{ id: "html-1", assetType: "linkHtmlContent" }],
+      });
+      const settings = createSettings();
+
+      await processBookmarkAssets(app, bookmark, "Article", client, settings);
+
+      expect(writtenFiles.length).toBe(0);
     });
   });
 });

--- a/src/asset-handler.ts
+++ b/src/asset-handler.ts
@@ -1,5 +1,6 @@
 import { App } from "obsidian";
 
+import { escapeAltText, escapeMarkdownPath } from "./formatting-utils";
 import { HoarderApiClient, HoarderBookmark } from "./hoarder-client";
 import { HoarderSettings } from "./settings";
 
@@ -8,9 +9,73 @@ export type AssetFrontmatter = {
   banner?: string; // wikilink [[path]]
   screenshot?: string; // wikilink [[path]]
   full_page_archive?: string; // wikilink [[path]]
+  pdf_archive?: string; // wikilink [[path]]
   video?: string; // wikilink [[path]] (only if downloaded, typically omitted)
   additional?: string[]; // array of wikilinks
 };
+
+const CONTENT_TYPE_TO_EXT: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/svg+xml": "svg",
+  "application/pdf": "pdf",
+  "text/html": "html",
+  "multipart/related": "mhtml",
+  "application/x-mimearchive": "mhtml",
+  "message/rfc822": "mhtml",
+};
+
+const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "gif", "webp", "svg"]);
+
+const SUPPORTED_EXTENSIONS = new Set([...IMAGE_EXTENSIONS, "pdf", "html", "mhtml"]);
+
+/**
+ * Determines the file extension for a downloaded asset.
+ *
+ * Priority: Content-Type header > asset label mapping > URL extension > "jpg" default
+ */
+export function resolveAssetExtension(
+  contentType: string | null,
+  assetLabel: string,
+  url: string
+): string {
+  if (contentType) {
+    const mimeType = contentType.split(";")[0].trim().toLowerCase();
+    const ext = CONTENT_TYPE_TO_EXT[mimeType];
+    if (ext) return ext;
+  }
+
+  const labelLower = assetLabel.toLowerCase();
+  if (labelLower.includes("pdf")) return "pdf";
+  if (labelLower.includes("full page archive")) return "mhtml";
+  if (labelLower.includes("screenshot")) return "png";
+
+  const urlExt = url.split("?")[0].split(".").pop()?.toLowerCase();
+  if (urlExt && SUPPORTED_EXTENSIONS.has(urlExt)) return urlExt;
+
+  return "jpg";
+}
+
+export function isImageExtension(ext: string): boolean {
+  return IMAGE_EXTENSIONS.has(ext.toLowerCase());
+}
+
+/**
+ * Returns true if the existing file can be reused (i.e., its extension is already
+ * correct for the expected asset type). Images are interchangeable (a .png banner
+ * doesn't need re-download just because we'd default to .jpg), but non-image types
+ * must match exactly.
+ */
+function canReuseExistingFile(existingFile: string, assetLabel: string, url: string): boolean {
+  const existingExt = existingFile.split(".").pop()?.toLowerCase() || "";
+  const expectedFromLabel = resolveAssetExtension(null, assetLabel, url);
+  if (isImageExtension(existingExt) && isImageExtension(expectedFromLabel)) {
+    return true;
+  }
+  return existingExt === expectedFromLabel;
+}
 
 function getAssetUrl(
   assetId: string,
@@ -20,31 +85,24 @@ function getAssetUrl(
   if (client) {
     return client.getAssetUrl(assetId);
   }
-  // Fallback if client is not initialized
   const baseUrl = settings.apiEndpoint.replace(/\/v1\/?$/, "");
   return `${baseUrl}/assets/${assetId}`;
 }
 
 export function sanitizeAssetFileName(title: string): string {
-  // Sanitize the title
   let sanitizedTitle = title
-    .replace(/[\\/:*?"<>|]/g, "-") // Replace invalid characters with dash
-    .replace(/\s+/g, "-") // Replace spaces with dash
-    .replace(/-+/g, "-") // Replace multiple dashes with single dash
-    .replace(/^-|-$/g, ""); // Remove dashes from start and end
+    .replace(/[^a-zA-Z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
 
-  // Use a shorter max length for asset filenames
   const maxTitleLength = 30;
 
   if (sanitizedTitle.length > maxTitleLength) {
-    // If title is too long, try to cut at a word boundary
     const truncated = sanitizedTitle.substring(0, maxTitleLength);
     const lastDash = truncated.lastIndexOf("-");
     if (lastDash > maxTitleLength / 2) {
-      // If we can find a reasonable word break, use it
       sanitizedTitle = truncated.substring(0, lastDash);
     } else {
-      // Otherwise just truncate
       sanitizedTitle = truncated;
     }
   }
@@ -52,50 +110,46 @@ export function sanitizeAssetFileName(title: string): string {
   return sanitizedTitle;
 }
 
-async function downloadImage(
+async function downloadAssetFile(
   app: App,
   url: string,
   assetId: string,
   title: string,
+  assetLabel: string,
   client: HoarderApiClient | null,
-  settings: HoarderSettings
+  settings: HoarderSettings,
+  existingFiles?: string[]
 ): Promise<string | null> {
   try {
-    // Create attachments folder if it doesn't exist
     if (!(await app.vault.adapter.exists(settings.attachmentsFolder))) {
       await app.vault.createFolder(settings.attachmentsFolder);
     }
 
-    // Get file extension from URL or default to jpg
-    const extension = url.split(".").pop()?.toLowerCase() || "jpg";
-    const safeExtension = ["jpg", "jpeg", "png", "gif", "webp"].includes(extension)
-      ? extension
-      : "jpg";
-
-    // Create a safe filename using just the assetId and a short title
-    const safeTitle = sanitizeAssetFileName(title);
-    const fileName = `${assetId}${safeTitle ? "-" + safeTitle : ""}.${safeExtension}`;
-    const filePath = `${settings.attachmentsFolder}/${fileName}`;
-
-    // Check if file already exists with any extension
-    const files = await app.vault.adapter.list(settings.attachmentsFolder);
-    const existingFile = files.files.find((filePathItem: string) =>
-      filePathItem.startsWith(`${settings.attachmentsFolder}/${assetId}`)
+    // Find existing file for this asset ID (from pre-fetched listing or fresh query)
+    let fileList = existingFiles;
+    if (!fileList) {
+      const listing = await app.vault.adapter.list(settings.attachmentsFolder);
+      fileList = listing.files;
+    }
+    const existingFile = fileList.find((f: string) =>
+      f.startsWith(`${settings.attachmentsFolder}/${assetId}`)
     );
-    if (existingFile) {
+
+    // If existing file has a correct extension, skip the download entirely
+    if (existingFile && canReuseExistingFile(existingFile, assetLabel, url)) {
       return existingFile;
     }
 
-    // Download the image
+    // Download the asset
     let buffer: ArrayBuffer;
+    let contentType: string | null = null;
 
-    // Check if this is a Hoarder asset URL by checking if it's from the same domain
     const apiDomain = new URL(settings.apiEndpoint).origin;
     if (url.startsWith(apiDomain) && client) {
-      // Use the client's downloadAsset method for Hoarder assets
-      buffer = await client.downloadAsset(assetId);
+      const result = await client.downloadAsset(assetId);
+      buffer = result.buffer;
+      contentType = result.contentType;
     } else {
-      // Use fetch for external URLs
       const headers: Record<string, string> = {};
       if (url.startsWith(apiDomain)) {
         headers["Authorization"] = `Bearer ${settings.apiKey}`;
@@ -105,25 +159,57 @@ async function downloadImage(
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
 
       buffer = await response.arrayBuffer();
+      contentType = response.headers.get("content-type");
     }
+
+    const extension = resolveAssetExtension(contentType, assetLabel, url);
+    const safeTitle = sanitizeAssetFileName(title);
+    const fileName = `${assetId}${safeTitle ? "-" + safeTitle : ""}.${extension}`;
+    const filePath = `${settings.attachmentsFolder}/${fileName}`;
+
     await app.vault.adapter.writeBinary(filePath, buffer);
+
+    // Remove the old file if it had a wrong extension
+    if (existingFile && existingFile !== filePath) {
+      try {
+        await app.vault.adapter.remove(existingFile);
+        console.log(`[Hoarder] Replaced misnamed asset: ${existingFile} -> ${filePath}`);
+      } catch (err) {
+        console.error(`[Hoarder] Failed to remove old asset file: ${existingFile}`, err);
+      }
+    }
 
     return filePath;
   } catch (error) {
-    console.error("Error downloading image:", url, error);
+    console.error("Error downloading asset:", url, error);
     return null;
   }
 }
 
-function escapeMarkdownPath(path: string): string {
-  // If path contains spaces or other special characters, wrap in angle brackets
-  if (path.includes(" ") || /[<>\[\](){}]/.test(path)) {
-    return `<${path}>`;
+function formatAssetEmbed(path: string, altText: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() || "";
+  const safeAlt = escapeAltText(altText);
+  if (ext === "pdf") {
+    return `\n![[${path}]]\n`;
   }
-  return path;
+  if (ext === "html" || ext === "mhtml") {
+    return `\n[${safeAlt}](${escapeMarkdownPath(path)})\n`;
+  }
+  return `\n![${safeAlt}](${escapeMarkdownPath(path)})\n`;
 }
 
 const toWikilink = (path: string): string => `"[[${path}]]"`;
+
+function shouldDownloadAssetType(label: string, settings: HoarderSettings): boolean {
+  if (!settings.downloadAssets) return false;
+
+  const labelLower = label.toLowerCase();
+  if (labelLower.includes("banner")) return settings.downloadBannerImages;
+  if (labelLower.includes("screenshot")) return settings.downloadScreenshots;
+  if (labelLower.includes("full page archive")) return settings.downloadFullPageArchives;
+  if (labelLower.includes("pdf")) return settings.downloadPdfArchives;
+  return true;
+}
 
 export async function processBookmarkAssets(
   app: App,
@@ -135,37 +221,71 @@ export async function processBookmarkAssets(
   let content = "";
   const fm: AssetFrontmatter = {};
 
-  // Handle images for asset type bookmarks
+  // Pre-fetch attachment file listing once for all asset downloads in this bookmark
+  let existingFiles: string[] | undefined;
+  if (settings.downloadAssets) {
+    try {
+      if (await app.vault.adapter.exists(settings.attachmentsFolder)) {
+        const listing = await app.vault.adapter.list(settings.attachmentsFolder);
+        existingFiles = listing.files;
+      }
+    } catch {
+      // Will fall back to per-download listing
+    }
+  }
+
   if (bookmark.content.type === "asset" && bookmark.content.assetType === "image") {
     if (bookmark.content.assetId) {
       const assetUrl = getAssetUrl(bookmark.content.assetId, client, settings);
       let imagePath: string | null = null;
-      if (settings.downloadAssets) {
-        imagePath = await downloadImage(
+      if (shouldDownloadAssetType("Banner Image", settings)) {
+        imagePath = await downloadAssetFile(
           app,
           assetUrl,
           bookmark.content.assetId,
           title,
+          "Banner Image",
           client,
-          settings
+          settings,
+          existingFiles
         );
       }
       if (imagePath) {
-        content += `\n![${title}](${escapeMarkdownPath(imagePath)})\n`;
+        content += formatAssetEmbed(imagePath, title);
         fm.image = toWikilink(imagePath);
       } else {
-        content += `\n![${title}](${escapeMarkdownPath(assetUrl)})\n`;
+        content += `\n![${escapeAltText(title)}](${escapeMarkdownPath(assetUrl)})\n`;
       }
     } else if (bookmark.content.sourceUrl) {
-      content += `\n![${title}](${escapeMarkdownPath(bookmark.content.sourceUrl)})\n`;
-      // No local path -> no wikilink in frontmatter
+      content += `\n![${escapeAltText(title)}](${escapeMarkdownPath(bookmark.content.sourceUrl)})\n`;
+    }
+  } else if (bookmark.content.type === "asset" && bookmark.content.assetType === "pdf") {
+    if (bookmark.content.assetId) {
+      const assetUrl = getAssetUrl(bookmark.content.assetId, client, settings);
+      let pdfPath: string | null = null;
+      if (shouldDownloadAssetType("PDF Archive", settings)) {
+        pdfPath = await downloadAssetFile(
+          app,
+          assetUrl,
+          bookmark.content.assetId,
+          title,
+          "PDF Archive",
+          client,
+          settings,
+          existingFiles
+        );
+      }
+      if (pdfPath) {
+        content += formatAssetEmbed(pdfPath, title);
+        fm.pdf_archive = toWikilink(pdfPath);
+      } else {
+        content += `\n[${escapeAltText(title)} - PDF](${escapeMarkdownPath(assetUrl)})\n`;
+      }
     }
   } else if (bookmark.content.type === "link") {
-    // For link types, handle all available assets
     const assetIds: string[] = [];
     const assetLabels: string[] = [];
 
-    // Collect all asset IDs and their labels
     if (bookmark.content.imageAssetId) {
       assetIds.push(bookmark.content.imageAssetId);
       assetLabels.push("Banner Image");
@@ -183,56 +303,50 @@ export async function processBookmarkAssets(
       assetLabels.push("Video");
     }
 
-    // Handle each asset
     for (let i = 0; i < assetIds.length; i++) {
       const assetId = assetIds[i];
       const label = assetLabels[i];
       const assetUrl = getAssetUrl(assetId, client, settings);
 
-      // Handle videos differently - just embed as links, don't download
       if (label === "Video") {
-        content += `\n[${title} - ${label}](${escapeMarkdownPath(assetUrl)})\n`;
-        // Not downloaded -> no wikilink in frontmatter
+        content += `\n[${escapeAltText(title)} - ${label}](${escapeMarkdownPath(assetUrl)})\n`;
       } else {
-        // Handle images normally
-        let imagePath: string | null = null;
-        if (settings.downloadAssets) {
-          imagePath = await downloadImage(
+        let assetPath: string | null = null;
+        if (shouldDownloadAssetType(label, settings)) {
+          assetPath = await downloadAssetFile(
             app,
             assetUrl,
             assetId,
             `${title}-${label}`,
+            label,
             client,
-            settings
+            settings,
+            existingFiles
           );
         }
-        if (imagePath) {
-          content += `\n![${title} - ${label}](${escapeMarkdownPath(imagePath)})\n`;
+        if (assetPath) {
+          content += formatAssetEmbed(assetPath, `${title} - ${label}`);
           if (label === "Banner Image") {
-            fm.banner = toWikilink(imagePath);
+            fm.banner = toWikilink(assetPath);
           } else if (label === "Screenshot") {
-            fm.screenshot = toWikilink(imagePath);
+            fm.screenshot = toWikilink(assetPath);
           } else if (label === "Full Page Archive") {
-            fm.full_page_archive = toWikilink(imagePath);
+            fm.full_page_archive = toWikilink(assetPath);
           }
         } else {
-          content += `\n![${title} - ${label}](${escapeMarkdownPath(assetUrl)})\n`;
+          content += `\n![${escapeAltText(title)} - ${label}](${escapeMarkdownPath(assetUrl)})\n`;
         }
       }
     }
 
-    // Handle external image URL if no asset IDs but imageUrl exists
     if (assetIds.length === 0 && bookmark.content.imageUrl) {
-      content += `\n![${title}](${escapeMarkdownPath(bookmark.content.imageUrl)})\n`;
-      // No local path -> no wikilink in frontmatter
+      content += `\n![${escapeAltText(title)}](${escapeMarkdownPath(bookmark.content.imageUrl)})\n`;
     }
   }
 
-  // Handle any additional assets from the bookmark.assets array
   if (bookmark.assets && bookmark.assets.length > 0) {
     const processedAssetIds = new Set<string>();
 
-    // Track which assets we've already processed from content fields
     if (bookmark.content.type === "asset" && bookmark.content.assetId) {
       processedAssetIds.add(bookmark.content.assetId);
     }
@@ -245,38 +359,46 @@ export async function processBookmarkAssets(
       if (bookmark.content.videoAssetId) processedAssetIds.add(bookmark.content.videoAssetId);
     }
 
-    // Process any remaining assets
     for (const asset of bookmark.assets) {
       if (!processedAssetIds.has(asset.id)) {
-        // Skip non-visual assets - these are stored content/data files, not embeddable media
         if (asset.assetType === "linkHtmlContent") {
           continue;
         }
 
         const assetUrl = getAssetUrl(asset.id, client, settings);
-        const label = asset.assetType === "image" ? "Additional Image" : asset.assetType;
+        const label =
+          asset.assetType === "image"
+            ? "Additional Image"
+            : asset.assetType === "pdf"
+              ? "PDF Archive"
+              : asset.assetType;
 
         if (asset.assetType === "video") {
-          content += `\n[${title} - ${label}](${escapeMarkdownPath(assetUrl)})\n`;
-          // Not downloaded -> no wikilink in frontmatter
+          content += `\n[${escapeAltText(title)} - ${label}](${escapeMarkdownPath(assetUrl)})\n`;
         } else {
-          let imagePath: string | null = null;
-          if (settings.downloadAssets) {
-            imagePath = await downloadImage(
+          let assetPath: string | null = null;
+          if (shouldDownloadAssetType(label, settings)) {
+            assetPath = await downloadAssetFile(
               app,
               assetUrl,
               asset.id,
               `${title}-${label}`,
+              label,
               client,
-              settings
+              settings,
+              existingFiles
             );
           }
-          if (imagePath) {
-            content += `\n![${title} - ${label}](${escapeMarkdownPath(imagePath)})\n`;
-            fm.additional = fm.additional || [];
-            fm.additional.push(toWikilink(imagePath));
+          if (assetPath) {
+            content += formatAssetEmbed(assetPath, `${title} - ${label}`);
+            if (asset.assetType === "pdf") {
+              fm.pdf_archive = toWikilink(assetPath);
+            } else {
+              fm.additional = fm.additional || [];
+              fm.additional.push(toWikilink(assetPath));
+            }
           } else {
-            content += `\n![${title} - ${label}](${escapeMarkdownPath(assetUrl)})\n`;
+            content += `\n![${escapeAltText(title)} - ${label}](${escapeMarkdownPath(assetUrl)})\n`;
           }
         }
       }

--- a/src/formatting-utils.test.ts
+++ b/src/formatting-utils.test.ts
@@ -1,4 +1,4 @@
-import { escapeMarkdownPath, escapeYaml } from "./formatting-utils";
+import { escapeMarkdownPath, escapeYaml, sanitizeHtml } from "./formatting-utils";
 
 describe("escapeYaml", () => {
   describe("null and empty handling", () => {
@@ -141,7 +141,7 @@ describe("escapeYaml", () => {
     });
 
     it("should wrap in single quotes when string contains double quotes even if also has single quotes", () => {
-      expect(escapeYaml("it's a \"test\"")).toBe("'it's a \"test\"'");
+      expect(escapeYaml('it\'s a "test"')).toBe("'it's a \"test\"'");
     });
   });
 
@@ -310,3 +310,79 @@ describe("escapeMarkdownPath", () => {
   });
 });
 
+describe("sanitizeHtml", () => {
+  it("should remove script tags and their content", () => {
+    expect(sanitizeHtml('<p>Hello</p><script>alert("xss")</script><p>World</p>')).toBe(
+      "<p>Hello</p><p>World</p>"
+    );
+  });
+
+  it("should remove self-closing script tags", () => {
+    expect(sanitizeHtml('<p>Hello</p><script src="evil.js"/><p>World</p>')).toBe(
+      "<p>Hello</p><p>World</p>"
+    );
+  });
+
+  it("should remove iframe tags", () => {
+    expect(sanitizeHtml('<iframe src="https://evil.com"></iframe>')).toBe("");
+  });
+
+  it("should remove style tags", () => {
+    expect(sanitizeHtml("<style>body { display: none }</style><p>Content</p>")).toBe(
+      "<p>Content</p>"
+    );
+  });
+
+  it("should remove form elements", () => {
+    expect(sanitizeHtml('<form action="/steal"><input type="text"></form>')).toBe("");
+  });
+
+  it("should remove object and embed tags", () => {
+    expect(sanitizeHtml('<object data="evil.swf"></object><embed src="evil.swf"/>')).toBe("");
+  });
+
+  it("should remove event handler attributes", () => {
+    expect(sanitizeHtml('<img src="photo.jpg" onerror="alert(1)">')).toBe(
+      '<img src="photo.jpg">'
+    );
+    expect(sanitizeHtml('<div onmouseover="steal()">text</div>')).toBe("<div>text</div>");
+  });
+
+  it("should remove javascript: URLs", () => {
+    const result = sanitizeHtml('<a href="javascript:alert(1)">click</a>');
+    expect(result).not.toContain("javascript:");
+    expect(result).toContain("click</a>");
+  });
+
+  it("should remove data: URLs in src", () => {
+    const result = sanitizeHtml('<img src="data:text/html,<script>alert(1)</script>">');
+    expect(result).not.toContain("data:");
+    expect(result).not.toContain("script");
+  });
+
+  it("should preserve safe HTML elements", () => {
+    const safe = "<h1>Title</h1><p>Paragraph with <strong>bold</strong> and <em>italic</em></p>";
+    expect(sanitizeHtml(safe)).toBe(safe);
+  });
+
+  it("should preserve links with normal URLs", () => {
+    const html = '<a href="https://example.com">Link</a>';
+    expect(sanitizeHtml(html)).toBe(html);
+  });
+
+  it("should preserve images with normal URLs", () => {
+    const html = '<img src="https://example.com/photo.jpg" alt="Photo">';
+    expect(sanitizeHtml(html)).toBe(html);
+  });
+
+  it("should preserve lists and blockquotes", () => {
+    const html = "<ul><li>Item 1</li><li>Item 2</li></ul><blockquote>Quote</blockquote>";
+    expect(sanitizeHtml(html)).toBe(html);
+  });
+
+  it("should handle multiple dangerous elements", () => {
+    const dirty =
+      '<p>Safe</p><script>bad()</script><iframe src="x"></iframe><p onclick="bad()">Also safe</p>';
+    expect(sanitizeHtml(dirty)).toBe("<p>Safe</p><p>Also safe</p>");
+  });
+});

--- a/src/formatting-utils.ts
+++ b/src/formatting-utils.ts
@@ -36,6 +36,39 @@ export function escapeYaml(str: string | null | undefined): string {
  * @param path - The path to escape
  * @returns The path, potentially wrapped in angle brackets
  */
+/**
+ * Escapes square brackets in markdown alt text / link text so they don't
+ * break the `![alt](url)` or `[text](url)` syntax.
+ */
+export function escapeAltText(text: string): string {
+  return text.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+}
+
+/**
+ * Strips dangerous HTML elements and attributes from crawled page content.
+ * Keeps readable content (p, h1-h6, ul, ol, li, blockquote, a, img, em, strong, etc.)
+ * but removes anything that could execute code or load external resources silently.
+ */
+export function sanitizeHtml(html: string): string {
+  // Remove dangerous tags and their content entirely
+  let safe = html.replace(
+    /<(script|iframe|object|embed|form|input|button|textarea|select|style|link|meta|base|applet|frame|frameset)[^>]*>[\s\S]*?<\/\1>/gi,
+    ""
+  );
+  // Remove self-closing dangerous tags
+  safe = safe.replace(
+    /<(script|iframe|object|embed|form|input|button|textarea|select|style|link|meta|base|applet|frame|frameset)[^>]*\/?>/gi,
+    ""
+  );
+  // Remove event handler attributes (on*)
+  safe = safe.replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "");
+  // Remove javascript: URLs in href/src attributes
+  safe = safe.replace(/(href|src|action)\s*=\s*(?:"javascript:[^"]*"|'javascript:[^']*')/gi, "");
+  // Remove data: URLs in src (can encode scripts)
+  safe = safe.replace(/src\s*=\s*(?:"data:[^"]*"|'data:[^']*')/gi, "");
+  return safe;
+}
+
 export function escapeMarkdownPath(path: string): string {
   // If path contains spaces or other special characters, wrap in angle brackets
   if (path.includes(" ") || /[<>[\](){}]/.test(path)) {

--- a/src/hoarder-client.test.ts
+++ b/src/hoarder-client.test.ts
@@ -1,6 +1,6 @@
-global.fetch = jest.fn();
-
 import { HoarderApiClient, HoarderHighlight } from "./hoarder-client";
+
+global.fetch = jest.fn();
 
 const mockFetch = global.fetch as jest.Mock;
 

--- a/src/hoarder-client.ts
+++ b/src/hoarder-client.ts
@@ -72,6 +72,7 @@ export interface BookmarkQueryParams {
   cursor?: string;
   archived?: boolean;
   favourited?: boolean;
+  includeContent?: boolean;
 }
 
 export class HoarderApiClient {
@@ -182,7 +183,9 @@ export class HoarderApiClient {
     return allHighlights;
   }
 
-  async downloadAsset(assetId: string): Promise<ArrayBuffer> {
+  async downloadAsset(
+    assetId: string
+  ): Promise<{ buffer: ArrayBuffer; contentType: string | null }> {
     const url = `${this.baseUrl}/assets/${assetId}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
@@ -200,7 +203,10 @@ export class HoarderApiClient {
           throw new Error(`HTTP ${response.status}: ${response.text || "Unknown error"}`);
         }
 
-        return response.arrayBuffer;
+        return {
+          buffer: response.arrayBuffer,
+          contentType: response.headers["content-type"] || null,
+        };
       } else {
         const response = await fetch(url, {
           method: "GET",
@@ -212,7 +218,10 @@ export class HoarderApiClient {
           throw new Error(`HTTP ${response.status}: ${errorText || "Unknown error"}`);
         }
 
-        return await response.arrayBuffer();
+        return {
+          buffer: await response.arrayBuffer(),
+          contentType: response.headers.get("content-type"),
+        };
       }
     } catch (error) {
       console.error("Asset download failed:", url, error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,17 +9,16 @@ import {
 } from "./deletion-handler";
 import { sanitizeFileName } from "./filename-utils";
 import { shouldIncludeBookmark } from "./filter-utils";
-import { escapeMarkdownPath, escapeYaml } from "./formatting-utils";
 import {
   HoarderApiClient,
   HoarderBookmark,
   HoarderHighlight,
   PaginatedBookmarks,
 } from "./hoarder-client";
-import { extractNotesSection } from "./markdown-utils";
+import { contentHasChanged, extractNotesSection } from "./markdown-utils";
 import { SyncStats, buildSyncMessage } from "./message-utils";
 import { DEFAULT_SETTINGS, HoarderSettingTab, HoarderSettings } from "./settings";
-import { sanitizeTags } from "./tag-utils";
+import { DEFAULT_TEMPLATE, buildTemplateContext, renderWithFallback } from "./template-renderer";
 
 export default class HoarderPlugin extends Plugin {
   settings: HoarderSettings;
@@ -121,11 +120,15 @@ export default class HoarderPlugin extends Plugin {
       throw new Error("Client not initialized");
     }
 
+    const template = this.settings.useCustomTemplate ? this.settings.customTemplate : "";
+    const needsHtmlContent = template.includes("content_html");
+
     return await this.client.getBookmarks({
       limit,
       cursor: cursor || undefined,
       archived: this.settings.excludeArchived ? false : undefined,
       favourited: this.settings.onlyFavorites ? true : undefined,
+      includeContent: needsHtmlContent || undefined,
     });
   }
 
@@ -161,13 +164,9 @@ export default class HoarderPlugin extends Plugin {
         return { currentNotes: null, originalNotes: null };
       }
 
-      const content = await this.app.vault.adapter.read(filePath);
-
-      // Extract notes from the content
-      const currentNotes = extractNotesSection(content);
-
-      // Use MetadataCache to get frontmatter
+      // Read both note values from frontmatter — this is template-independent
       const metadata = this.app.metadataCache.getFileCache(file)?.frontmatter;
+      const currentNotes = metadata?.note ?? null;
       const originalNotes = metadata?.original_note ?? null;
 
       return { currentNotes, originalNotes };
@@ -477,7 +476,7 @@ export default class HoarderPlugin extends Plugin {
                 if (originalNotes === null && currentNotes !== null) {
                   console.debug(`[Hoarder] original_note missing for ${fileName}`);
 
-                  // If current notes differ from remote, sync them
+                  // If current notes differ from remote, sync them to Hoarder
                   if (currentNotes !== remoteNotes) {
                     console.log(`[Hoarder] Local notes differ from remote, syncing to Hoarder`);
                     const updated = await this.updateBookmarkInHoarder(bookmark.id, currentNotes);
@@ -485,23 +484,10 @@ export default class HoarderPlugin extends Plugin {
                       updatedInHoarder++;
                       bookmark.note = currentNotes; // Update the bookmark object with local notes
                       this.lastSyncedNotes = currentNotes; // Track this to avoid re-syncing
-
-                      // Now initialize original_note to match the synced version
-                      console.debug(
-                        `[Hoarder] Initializing original_note to synced value for ${fileName}`
-                      );
-                      await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
-                        frontmatter["original_note"] = currentNotes;
-                      });
                     }
-                  } else {
-                    // Current notes match remote, only update frontmatter if they're different
-                    // Since currentNotes === remoteNotes, we can skip the frontmatter update entirely
-                    // to avoid changing mtime. The frontmatter will be initialized on the next actual change.
-                    console.debug(
-                      `[Hoarder] Notes match remote, skipping original_note initialization to preserve mtime`
-                    );
                   }
+                  // original_note will be written as part of formatBookmarkAsMarkdown below,
+                  // so no need for a separate processFrontMatter call that would touch mtime
                 } else if (
                   currentNotes !== null &&
                   originalNotes !== null &&
@@ -523,12 +509,12 @@ export default class HoarderPlugin extends Plugin {
               const newContent = await this.formatBookmarkAsMarkdown(bookmark, title, highlights);
               const existingContent = await this.app.vault.adapter.read(fileName);
 
-              if (existingContent !== newContent) {
+              if (contentHasChanged(existingContent, newContent)) {
                 // Content has actually changed, update the file
                 await this.app.vault.adapter.write(fileName, newContent);
                 totalBookmarks++;
               } else {
-                // Content is identical, skip writing to preserve modification time
+                // Content is semantically identical, skip writing to preserve mtime
                 this.skippedFiles++;
               }
             }
@@ -584,14 +570,6 @@ export default class HoarderPlugin extends Plugin {
     title: string,
     highlights?: HoarderHighlight[]
   ): Promise<string> {
-    const url =
-      bookmark.content.type === "link" ? bookmark.content.url : bookmark.content.sourceUrl;
-    const description =
-      bookmark.content.type === "link" ? bookmark.content.description : bookmark.content.text;
-    const rawTags = bookmark.tags.map((tag) => tag.name);
-    const tags = sanitizeTags(rawTags);
-
-    // Handle images and assets first to collect frontmatter entries
     const { content: assetContent, frontmatter: assetsFm } = await processBookmarkAssets(
       this.app,
       bookmark,
@@ -600,105 +578,21 @@ export default class HoarderPlugin extends Plugin {
       this.settings
     );
 
-    // Build top-level asset YAML entries (wikilinks only)
-    let assetsYaml = "";
-    if (assetsFm) {
-      const lines: string[] = [];
-      if (assetsFm.image) lines.push(`image: ${assetsFm.image}`);
-      if (assetsFm.banner) lines.push(`banner: ${assetsFm.banner}`);
-      if (assetsFm.screenshot) lines.push(`screenshot: ${assetsFm.screenshot}`);
-      if (assetsFm.full_page_archive)
-        lines.push(`full_page_archive: ${assetsFm.full_page_archive}`);
-      if (assetsFm.video) lines.push(`video: ${assetsFm.video}`);
-      if (assetsFm.additional && assetsFm.additional.length > 0) {
-        lines.push("additional:");
-        for (const link of assetsFm.additional) {
-          lines.push(`  - ${link}`);
-        }
-      }
-      assetsYaml = lines.join("\n") + "\n";
-    }
+    const context = buildTemplateContext(
+      bookmark,
+      title,
+      highlights,
+      assetContent,
+      assetsFm,
+      this.settings
+    );
 
-    // Build tags YAML - only include if there are valid tags
-    const tagsYaml = tags.length > 0 ? `tags:\n  - ${tags.join("\n  - ")}\n` : "";
+    const template =
+      this.settings.useCustomTemplate && this.settings.customTemplate
+        ? this.settings.customTemplate
+        : DEFAULT_TEMPLATE;
 
-    let content = `---
-bookmark_id: "${bookmark.id}"
-url: ${escapeYaml(url)}
-title: ${escapeYaml(title)}
-date: ${new Date(bookmark.createdAt).toISOString()}
-${bookmark.modifiedAt ? `modified: ${new Date(bookmark.modifiedAt).toISOString()}\n` : ""}${tagsYaml}note: ${escapeYaml(bookmark.note)}
-original_note: ${escapeYaml(bookmark.note)}
-summary: ${escapeYaml(bookmark.summary)}
-${assetsYaml}
----
-
-# ${title}
-`;
-
-    // Append any asset content (images/links embeds)
-    content += assetContent;
-
-    // Add summary if available
-    if (bookmark.summary) {
-      content += `\n## Summary\n\n${bookmark.summary}\n`;
-    }
-
-    // Add description if available
-    if (description) {
-      content += `\n## Description\n\n${description}\n`;
-    }
-
-    // Add highlights if available and enabled
-    if (highlights && highlights.length > 0 && this.settings.syncHighlights) {
-      content += `\n## Highlights\n\n`;
-
-      // Sort highlights by startOffset (position in document)
-      const sortedHighlights = highlights.sort((a, b) => a.startOffset - b.startOffset);
-
-      for (const highlight of sortedHighlights) {
-        const date = new Date(highlight.createdAt).toLocaleDateString("en-US", {
-          year: "numeric",
-          month: "long",
-          day: "numeric",
-        });
-
-        content += `> [!karakeep-${highlight.color}] ${date}\n`;
-
-        // Handle multi-line highlight text by prefixing each line with '> '
-        const highlightLines = highlight.text.split("\n");
-        for (const line of highlightLines) {
-          content += `> ${line}\n`;
-        }
-
-        if (highlight.note && highlight.note.trim()) {
-          content += `>\n`;
-          // Handle multi-line notes by prefixing each line with '> '
-          const noteLines = highlight.note.split("\n");
-          for (let i = 0; i < noteLines.length; i++) {
-            if (i === 0) {
-              content += `> *Note: ${noteLines[i]}*\n`;
-            } else {
-              content += `> *${noteLines[i]}*\n`;
-            }
-          }
-        }
-
-        content += `\n`;
-      }
-    }
-
-    // Always add Notes section
-    content += `\n## Notes\n\n${bookmark.note || ""}\n`;
-
-    // Add link if available (and it's not just an image)
-    if (url && bookmark.content.type !== "asset") {
-      content += `\n[Visit Link](${escapeMarkdownPath(url)})\n`;
-    }
-    const hoarderUrl = `${this.settings.apiEndpoint.replace("/api/v1", "/dashboard/preview")}/${bookmark.id}`;
-    content += `\n[View in Hoarder](${escapeMarkdownPath(hoarderUrl)})`;
-
-    return content;
+    return renderWithFallback(template, context);
   }
 
   private async handleFileModification(file: TFile) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,13 @@ import {
 import { contentHasChanged, extractNotesSection } from "./markdown-utils";
 import { SyncStats, buildSyncMessage } from "./message-utils";
 import { DEFAULT_SETTINGS, HoarderSettingTab, HoarderSettings } from "./settings";
-import { DEFAULT_TEMPLATE, buildTemplateContext, renderWithFallback } from "./template-renderer";
+import {
+  DEFAULT_TEMPLATE,
+  NOTE_BLOCK_END,
+  NOTE_BLOCK_START,
+  buildTemplateContext,
+  renderWithFallback,
+} from "./template-renderer";
 
 export default class HoarderPlugin extends Plugin {
   settings: HoarderSettings;
@@ -164,12 +170,26 @@ export default class HoarderPlugin extends Plugin {
         return { currentNotes: null, originalNotes: null };
       }
 
-      // Read both note values from frontmatter — this is template-independent
       const metadata = this.app.metadataCache.getFileCache(file)?.frontmatter;
-      const currentNotes = metadata?.note ?? null;
       const originalNotes = metadata?.original_note ?? null;
+      const content = await this.app.vault.adapter.read(filePath);
 
-      return { currentNotes, originalNotes };
+      // 1. Comment block (custom templates using noteBlock)
+      const blockMatch = content.match(
+        new RegExp(`${NOTE_BLOCK_START}\\n([\\s\\S]*?)\\n${NOTE_BLOCK_END}`)
+      );
+      if (blockMatch) {
+        return { currentNotes: blockMatch[1], originalNotes };
+      }
+
+      // 2. ## Notes section (default template)
+      const sectionNotes = extractNotesSection(content);
+      if (sectionNotes !== null) {
+        return { currentNotes: sectionNotes, originalNotes };
+      }
+
+      // 3. Frontmatter note field (last resort)
+      return { currentNotes: metadata?.note ?? null, originalNotes };
     } catch (error) {
       console.error("Error reading file:", error);
       return { currentNotes: null, originalNotes: null };

--- a/src/main.ts
+++ b/src/main.ts
@@ -276,6 +276,9 @@ export default class HoarderPlugin extends Plugin {
               instruction.reason === "deleted"
                 ? this.settings.archiveFolder
                 : this.settings.archivedBookmarkFolder;
+            if (instruction.reason === "archived" && file.path.startsWith(`${archiveFolder}/`)) {
+              break;
+            }
             await this.moveToArchiveFolder(file, archiveFolder);
             break;
 
@@ -298,6 +301,11 @@ export default class HoarderPlugin extends Plugin {
   async moveToArchiveFolder(file: TFile, archiveFolder: string): Promise<void> {
     if (!archiveFolder) {
       throw new Error("Archive folder not configured");
+    }
+
+    // Already in the archive folder, nothing to do
+    if (file.path.startsWith(`${archiveFolder}/`)) {
+      return;
     }
 
     // Create archive folder if it doesn't exist

--- a/src/markdown-utils.test.ts
+++ b/src/markdown-utils.test.ts
@@ -1,4 +1,9 @@
-import { extractNotesSection } from "./markdown-utils";
+import {
+  contentHasChanged,
+  extractNotesSection,
+  parseFrontmatter,
+  splitFrontmatterAndBody,
+} from "./markdown-utils";
 
 describe("extractNotesSection", () => {
   describe("basic extraction", () => {
@@ -15,6 +20,11 @@ describe("extractNotesSection", () => {
     it("should trim whitespace", () => {
       const content = "## Notes\n\n  My note  \n\n";
       expect(extractNotesSection(content)).toBe("My note");
+    });
+
+    it("should extract notes with only one newline after heading", () => {
+      const content = "## Notes\nMy note with single newline";
+      expect(extractNotesSection(content)).toBe("My note with single newline");
     });
 
     it("should return null if no notes section", () => {
@@ -61,9 +71,15 @@ describe("extractNotesSection", () => {
       expect(extractNotesSection(content)).toBe("My note");
     });
 
-    it("should handle multiple links", () => {
-      const content = "## Notes\n\nMy note\n\n[Link 1](url1)\n[Link 2](url2)";
+    it("should handle multiple footer links", () => {
+      const content =
+        "## Notes\n\nMy note\n\n[Visit Link](url1)\n[View in Hoarder](url2)";
       expect(extractNotesSection(content)).toBe("My note");
+    });
+
+    it("should NOT truncate at generic links in notes", () => {
+      const content = "## Notes\n\nMy note\n[some link](url)\nMore note";
+      expect(extractNotesSection(content)).toBe("My note\n[some link](url)\nMore note");
     });
   });
 
@@ -78,8 +94,8 @@ describe("extractNotesSection", () => {
       expect(extractNotesSection(content)).toBe("My note");
     });
 
-    it("should extract notes before links at end", () => {
-      const content = "## Notes\n\nMy note\n\n[Link](url)";
+    it("should extract notes before Visit Link at end", () => {
+      const content = "## Notes\n\nMy note\n\n[Visit Link](url)";
       expect(extractNotesSection(content)).toBe("My note");
     });
   });
@@ -248,5 +264,137 @@ Important: Remember to follow up on this!
       const content = "## Notes\n\nEnglish and 中文 mixed\n\n## Summary";
       expect(extractNotesSection(content)).toBe("English and 中文 mixed");
     });
+  });
+});
+
+describe("splitFrontmatterAndBody", () => {
+  it("should split content with frontmatter", () => {
+    const content = "---\ntitle: Test\n---\n\n# Body";
+    const result = splitFrontmatterAndBody(content);
+    expect(result.frontmatter).toBe("title: Test");
+    expect(result.body).toBe("\n# Body");
+  });
+
+  it("should handle content without frontmatter", () => {
+    const content = "# Just a body";
+    const result = splitFrontmatterAndBody(content);
+    expect(result.frontmatter).toBe("");
+    expect(result.body).toBe("# Just a body");
+  });
+
+  it("should handle empty frontmatter", () => {
+    const content = "---\n\n---\nBody";
+    const result = splitFrontmatterAndBody(content);
+    expect(result.frontmatter).toBe("");
+    expect(result.body).toBe("Body");
+  });
+});
+
+describe("parseFrontmatter", () => {
+  it("should parse simple key-value pairs", () => {
+    const yaml = 'bookmark_id: "abc123"\ntitle: My Title';
+    const result = parseFrontmatter(yaml);
+    expect(result.bookmark_id).toBe("abc123");
+    expect(result.title).toBe("My Title");
+  });
+
+  it("should parse quoted values", () => {
+    const yaml = "title: \"quoted value\"\nother: 'single quoted'";
+    const result = parseFrontmatter(yaml);
+    expect(result.title).toBe("quoted value");
+    expect(result.other).toBe("single quoted");
+  });
+
+  it("should parse block scalars", () => {
+    const yaml = "note: |\n  line one\n  line two";
+    const result = parseFrontmatter(yaml);
+    expect(result.note).toBe("line one\nline two");
+  });
+
+  it("should parse arrays", () => {
+    const yaml = "tags:\n  - tag1\n  - tag2\n  - tag3";
+    const result = parseFrontmatter(yaml);
+    expect(result.tags).toEqual(["tag1", "tag2", "tag3"]);
+  });
+
+  it("should handle empty values", () => {
+    const yaml = "note: ";
+    const result = parseFrontmatter(yaml);
+    expect(result.note).toBe("");
+  });
+
+  it("should skip empty lines", () => {
+    const yaml = "title: Test\n\ndate: 2024-01-01";
+    const result = parseFrontmatter(yaml);
+    expect(result.title).toBe("Test");
+    expect(result.date).toBe("2024-01-01");
+  });
+});
+
+describe("contentHasChanged", () => {
+  const makeContent = (fm: string, body: string) => `---\n${fm}\n---\n${body}`;
+
+  it("should return false for identical content", () => {
+    const content = makeContent("title: Test\nnote: hello", "\n# Test\n");
+    expect(contentHasChanged(content, content)).toBe(false);
+  });
+
+  it("should return true when body changes", () => {
+    const existing = makeContent("title: Test", "\n# Old Title\n");
+    const updated = makeContent("title: Test", "\n# New Title\n");
+    expect(contentHasChanged(existing, updated)).toBe(true);
+  });
+
+  it("should return true when frontmatter values change", () => {
+    const existing = makeContent("title: Old Title", "\n# Test\n");
+    const updated = makeContent("title: New Title", "\n# Test\n");
+    expect(contentHasChanged(existing, updated)).toBe(true);
+  });
+
+  it("should return false when only YAML formatting differs", () => {
+    // Hand-built template uses block scalar, Obsidian might use quoted string
+    const existing = makeContent('title: "My Title"\nnote: hello', "\n# Test\n");
+    const updated = makeContent("title: My Title\nnote: hello", "\n# Test\n");
+    expect(contentHasChanged(existing, updated)).toBe(false);
+  });
+
+  it("should return false when a field is missing vs empty string", () => {
+    const existing = makeContent("title: Test", "\n# Test\n");
+    const updated = makeContent("title: Test\nnote: ", "\n# Test\n");
+    expect(contentHasChanged(existing, updated)).toBe(false);
+  });
+
+  it("should return true when a new tag is added", () => {
+    const existing = makeContent("tags:\n  - tag1", "\n# Test\n");
+    const updated = makeContent("tags:\n  - tag1\n  - tag2", "\n# Test\n");
+    expect(contentHasChanged(existing, updated)).toBe(true);
+  });
+
+  it("should handle the real-world Obsidian vs plugin formatting case", () => {
+    // Plugin generates this format
+    const pluginGenerated = makeContent(
+      'bookmark_id: "abc123"\nurl: |\n  https://example.com\ntitle: My Article\ndate: 2024-01-15T10:30:00.000Z\nnote: \noriginal_note: \nsummary: A good article',
+      "\n# My Article\n"
+    );
+
+    // Obsidian processFrontMatter might reformat to this (different quoting)
+    const obsidianFormatted = makeContent(
+      "bookmark_id: abc123\nurl: https://example.com\ntitle: My Article\ndate: 2024-01-15T10:30:00.000Z\nnote: \noriginal_note: \nsummary: A good article",
+      "\n# My Article\n"
+    );
+
+    expect(contentHasChanged(obsidianFormatted, pluginGenerated)).toBe(false);
+  });
+
+  it("should detect real note content changes", () => {
+    const existing = makeContent(
+      "bookmark_id: abc123\nnote: old note\noriginal_note: old note",
+      "\n# Test\n\n## Notes\n\nold note\n"
+    );
+    const updated = makeContent(
+      "bookmark_id: abc123\nnote: new note\noriginal_note: new note",
+      "\n# Test\n\n## Notes\n\nnew note\n"
+    );
+    expect(contentHasChanged(existing, updated)).toBe(true);
   });
 });

--- a/src/markdown-utils.ts
+++ b/src/markdown-utils.ts
@@ -12,6 +12,127 @@
  * @returns The notes content (trimmed), or null if no notes section found
  */
 export function extractNotesSection(content: string): string | null {
-  const notesMatch = content.match(/## Notes\n\n([\s\S]*?)(?=\n##|\n\[|$)/);
-  return notesMatch ? notesMatch[1].trim() : null;
+  const notesMatch = content.match(/## Notes\n\n?([\s\S]*?)(?=\n##|$)/);
+  if (!notesMatch) return null;
+  // Strip trailing markdown links (footer links like [Visit Link] and [View in Hoarder])
+  const trimmed = notesMatch[1].replace(/(\n\[[\w\s]+\]\([^)]*\)\s*)+$/, "");
+  return trimmed.trim();
+}
+
+/**
+ * Splits markdown content into frontmatter and body.
+ *
+ * @param content - The full markdown file content
+ * @returns An object with `frontmatter` (raw YAML string) and `body` (everything after closing ---)
+ */
+export function splitFrontmatterAndBody(content: string): {
+  frontmatter: string;
+  body: string;
+} {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) {
+    return { frontmatter: "", body: content };
+  }
+  return { frontmatter: match[1], body: match[2] };
+}
+
+/**
+ * Parses simple YAML frontmatter into a key-value map.
+ * Handles scalar values, block scalars (|), and simple arrays (tags).
+ * Designed specifically for the frontmatter format this plugin generates.
+ */
+export function parseFrontmatter(yaml: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const lines = yaml.split("\n");
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    const kvMatch = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)/);
+    if (!kvMatch) {
+      i++;
+      continue;
+    }
+
+    const key = kvMatch[1];
+    let value = kvMatch[2];
+
+    // Block scalar (|)
+    if (value === "|") {
+      const blockLines: string[] = [];
+      i++;
+      while (i < lines.length && /^  /.test(lines[i])) {
+        blockLines.push(lines[i].substring(2));
+        i++;
+      }
+      result[key] = blockLines.join("\n");
+      continue;
+    }
+
+    // Array (indented "- " items)
+    if (value === "" && i + 1 < lines.length && lines[i + 1].startsWith("  - ")) {
+      const items: string[] = [];
+      i++;
+      while (i < lines.length && lines[i].startsWith("  - ")) {
+        items.push(lines[i].substring(4));
+        i++;
+      }
+      result[key] = items;
+      continue;
+    }
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    result[key] = value;
+    i++;
+  }
+
+  return result;
+}
+
+/**
+ * Compares two markdown documents semantically, ignoring frontmatter formatting differences.
+ * Returns true if the content has meaningfully changed.
+ */
+export function contentHasChanged(existingContent: string, newContent: string): boolean {
+  const existing = splitFrontmatterAndBody(existingContent);
+  const generated = splitFrontmatterAndBody(newContent);
+
+  if (existing.body !== generated.body) {
+    return true;
+  }
+
+  const existingFm = parseFrontmatter(existing.frontmatter);
+  const generatedFm = parseFrontmatter(generated.frontmatter);
+  const allKeys = new Set([...Object.keys(existingFm), ...Object.keys(generatedFm)]);
+
+  for (const key of allKeys) {
+    const a = existingFm[key];
+    const b = generatedFm[key];
+
+    // Treat missing/null and empty string as equivalent
+    const normA = a === undefined || a === null ? "" : a;
+    const normB = b === undefined || b === null ? "" : b;
+
+    if (Array.isArray(normA) && Array.isArray(normB)) {
+      if (normA.length !== normB.length || normA.some((v, i) => v !== normB[i])) {
+        return true;
+      }
+    } else if (normA !== normB) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -385,7 +385,8 @@ export class HoarderSettingTab extends PluginSettingTab {
       refContent.innerHTML = `
 <strong>Bookmark fields</strong>
 <code>it.bookmark_id</code> <code>it.title</code> <code>it.url</code> <code>it.description</code>
-<code>it.note</code> <code>it.summary</code> <code>it.created_at</code> <code>it.modified_at</code>
+<code>it.note</code> (raw text) <code>it.noteBlock</code> (editable, wrapped in comment markers)
+<code>it.summary</code> <code>it.created_at</code> <code>it.modified_at</code>
 <code>it.content_type</code> ("link", "text", "asset") <code>it.content_html</code>
 <code>it.archived</code> <code>it.favourited</code>
 <code>it.tags</code> (string array) <code>it.hoarder_url</code> <code>it.visit_link</code>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,9 @@
+import { EditorView } from "@codemirror/view";
 import { AbstractInputSuggest, App, Notice, PluginSettingTab, Setting, TFolder } from "obsidian";
 
 import HoarderPlugin from "./main";
+import { createTemplateEditor, setEditorValue } from "./template-editor";
+import { DEFAULT_TEMPLATE, validateTemplate } from "./template-renderer";
 
 export interface HoarderSettings {
   apiKey: string;
@@ -18,6 +21,10 @@ export interface HoarderSettings {
   excludedTags: string[];
   includedTags: string[];
   downloadAssets: boolean;
+  downloadBannerImages: boolean;
+  downloadScreenshots: boolean;
+  downloadPdfArchives: boolean;
+  downloadFullPageArchives: boolean;
   syncDeletions: boolean;
   deletionAction: "delete" | "archive" | "tag";
   deletionTag: string;
@@ -27,6 +34,8 @@ export interface HoarderSettings {
   archivedBookmarkTag: string;
   archivedBookmarkFolder: string;
   useObsidianRequest: boolean;
+  useCustomTemplate: boolean;
+  customTemplate: string;
 }
 
 export const DEFAULT_SETTINGS: HoarderSettings = {
@@ -45,6 +54,10 @@ export const DEFAULT_SETTINGS: HoarderSettings = {
   excludedTags: [],
   includedTags: [],
   downloadAssets: true,
+  downloadBannerImages: true,
+  downloadScreenshots: true,
+  downloadPdfArchives: true,
+  downloadFullPageArchives: false,
   syncDeletions: false,
   deletionAction: "delete",
   deletionTag: "deleted",
@@ -54,6 +67,8 @@ export const DEFAULT_SETTINGS: HoarderSettings = {
   archivedBookmarkTag: "archived",
   archivedBookmarkFolder: "Hoarder/archived",
   useObsidianRequest: false,
+  useCustomTemplate: false,
+  customTemplate: "",
 };
 
 class FolderSuggest extends AbstractInputSuggest<TFolder> {
@@ -95,6 +110,7 @@ class FolderSuggest extends AbstractInputSuggest<TFolder> {
 export class HoarderSettingTab extends PluginSettingTab {
   plugin: HoarderPlugin;
   syncButton: any;
+  private templateEditor: EditorView | null = null;
 
   constructor(app: App, plugin: HoarderPlugin) {
     super(app, plugin);
@@ -102,8 +118,11 @@ export class HoarderSettingTab extends PluginSettingTab {
   }
 
   onunload() {
-    // Clean up event listener
     this.plugin.events.off("sync-state-change", this.updateSyncButton);
+    if (this.templateEditor) {
+      this.templateEditor.destroy();
+      this.templateEditor = null;
+    }
   }
 
   private updateSyncButton = (isSyncing: boolean) => {
@@ -116,6 +135,7 @@ export class HoarderSettingTab extends PluginSettingTab {
   display(): void {
     const { containerEl } = this;
     containerEl.empty();
+    containerEl.addClass("hoarder-settings");
 
     // =================
     // API Configuration
@@ -123,7 +143,7 @@ export class HoarderSettingTab extends PluginSettingTab {
     containerEl.createEl("h3", { text: "API Configuration" });
     containerEl.createEl("div", {
       text: "Connection settings for your Karakeep instance",
-      cls: "setting-item-description",
+      cls: "hoarder-section-description",
     });
 
     new Setting(containerEl)
@@ -172,7 +192,7 @@ export class HoarderSettingTab extends PluginSettingTab {
     containerEl.createEl("h3", { text: "File Organization" });
     containerEl.createEl("div", {
       text: "Configure where your bookmarks and assets are stored",
-      cls: "setting-item-description",
+      cls: "hoarder-section-description",
     });
 
     new Setting(containerEl)
@@ -215,7 +235,7 @@ export class HoarderSettingTab extends PluginSettingTab {
     containerEl.createEl("h3", { text: "Sync Behavior" });
     containerEl.createEl("div", {
       text: "Control how synchronization works",
-      cls: "setting-item-description",
+      cls: "hoarder-section-description",
     });
 
     new Setting(containerEl)
@@ -277,8 +297,169 @@ export class HoarderSettingTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.downloadAssets).onChange(async (value) => {
           this.plugin.settings.downloadAssets = value;
           await this.plugin.saveSettings();
+          this.display();
         })
       );
+
+    if (this.plugin.settings.downloadAssets) {
+      new Setting(containerEl)
+        .setName("Download banner images")
+        .setDesc("Download banner/preview images for bookmarks")
+        .addToggle((toggle) =>
+          toggle.setValue(this.plugin.settings.downloadBannerImages).onChange(async (value) => {
+            this.plugin.settings.downloadBannerImages = value;
+            await this.plugin.saveSettings();
+          })
+        );
+
+      new Setting(containerEl)
+        .setName("Download screenshots")
+        .setDesc("Download page screenshots")
+        .addToggle((toggle) =>
+          toggle.setValue(this.plugin.settings.downloadScreenshots).onChange(async (value) => {
+            this.plugin.settings.downloadScreenshots = value;
+            await this.plugin.saveSettings();
+          })
+        );
+
+      new Setting(containerEl)
+        .setName("Download PDF archives")
+        .setDesc("Download PDF archives of bookmarked pages")
+        .addToggle((toggle) =>
+          toggle.setValue(this.plugin.settings.downloadPdfArchives).onChange(async (value) => {
+            this.plugin.settings.downloadPdfArchives = value;
+            await this.plugin.saveSettings();
+          })
+        );
+
+      new Setting(containerEl)
+        .setName("Download full page archives")
+        .setDesc("Download full page archives (MHTML/HTML) — can be large")
+        .addToggle((toggle) =>
+          toggle.setValue(this.plugin.settings.downloadFullPageArchives).onChange(async (value) => {
+            this.plugin.settings.downloadFullPageArchives = value;
+            await this.plugin.saveSettings();
+          })
+        );
+    }
+
+    // =================
+    // Note Template
+    // =================
+    containerEl.createEl("h3", { text: "Note Template" });
+    containerEl.createEl("div", {
+      text: "Customize the format of synced bookmark notes using Eta template syntax",
+      cls: "hoarder-section-description",
+    });
+
+    new Setting(containerEl)
+      .setName("Use custom template")
+      .setDesc("Enable a custom template for bookmark note generation")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.useCustomTemplate).onChange(async (value) => {
+          this.plugin.settings.useCustomTemplate = value;
+          if (value && !this.plugin.settings.customTemplate) {
+            this.plugin.settings.customTemplate = DEFAULT_TEMPLATE;
+          }
+          await this.plugin.saveSettings();
+          this.display();
+        })
+      );
+
+    if (this.plugin.settings.useCustomTemplate) {
+      if (this.plugin.settings.syncNotesToHoarder) {
+        containerEl.createEl("div", {
+          text: "Warning: Your template must include a ## Notes section and original_note frontmatter field for bi-directional sync to work.",
+          cls: "hoarder-section-description",
+        }).style.color = "var(--text-error)";
+      }
+
+      containerEl.createEl("div", {
+        text: "Eta template for bookmark notes. Use <%= it.variable %> for output, <% if (condition) { %> for logic.",
+        cls: "hoarder-section-description",
+      });
+
+      const details = containerEl.createEl("details", { cls: "hoarder-template-reference" });
+      details.createEl("summary", { text: "Available template variables" });
+      const refContent = details.createEl("div", { cls: "hoarder-template-ref-content" });
+      refContent.innerHTML = `
+<strong>Bookmark fields</strong>
+<code>it.bookmark_id</code> <code>it.title</code> <code>it.url</code> <code>it.description</code>
+<code>it.note</code> <code>it.summary</code> <code>it.created_at</code> <code>it.modified_at</code>
+<code>it.content_type</code> ("link", "text", "asset") <code>it.content_html</code>
+<code>it.archived</code> <code>it.favourited</code>
+<code>it.tags</code> (string array) <code>it.hoarder_url</code> <code>it.visit_link</code>
+
+<strong>Pre-escaped for YAML frontmatter</strong>
+<code>it.yaml.url</code> <code>it.yaml.title</code> <code>it.yaml.note</code> <code>it.yaml.summary</code>
+
+<strong>Assets</strong>
+<code>it.assets.content</code> (rendered embeds)
+<code>it.assets.banner</code> <code>it.assets.screenshot</code> <code>it.assets.image</code>
+<code>it.assets.full_page_archive</code> <code>it.assets.pdf_archive</code> <code>it.assets.video</code>
+<code>it.assets.additional</code> (string array)
+
+<strong>Highlights</strong> (array, each has:)
+<code>.id</code> <code>.color</code> <code>.text</code> <code>.note</code> <code>.date</code> <code>.created_at</code>
+<code>it.sync_highlights</code> (boolean)
+
+<strong>Helper functions</strong>
+<code>it.escapeYaml(str)</code> <code>it.escapeMarkdownPath(str)</code> <code>it.formatDate(iso)</code>
+      `.trim();
+
+      const editorContainer = containerEl.createDiv({ cls: "hoarder-template-editor" });
+
+      // Clean up previous editor if re-rendering
+      if (this.templateEditor) {
+        this.templateEditor.destroy();
+        this.templateEditor = null;
+      }
+
+      let templateSaveTimeout: number | null = null;
+      const warningContainer = containerEl.createDiv({ cls: "hoarder-template-warnings" });
+
+      this.templateEditor = createTemplateEditor(
+        editorContainer,
+        this.plugin.settings.customTemplate || DEFAULT_TEMPLATE,
+        (value) => {
+          if (templateSaveTimeout) window.clearTimeout(templateSaveTimeout);
+          templateSaveTimeout = window.setTimeout(async () => {
+            const result = validateTemplate(value);
+            warningContainer.empty();
+            if (result.valid) {
+              this.plugin.settings.customTemplate = value;
+              await this.plugin.saveSettings();
+              if (result.warnings) {
+                for (const warning of result.warnings) {
+                  warningContainer.createDiv({
+                    text: `Warning: ${warning}`,
+                    cls: "hoarder-template-warning",
+                  });
+                }
+              }
+            } else {
+              warningContainer.createDiv({
+                text: `Error: ${result.error}`,
+                cls: "hoarder-template-error",
+              });
+            }
+          }, 500);
+        }
+      );
+
+      new Setting(containerEl)
+        .setName("Reset template")
+        .setDesc("Reset the template to its default")
+        .addButton((button) =>
+          button.setButtonText("Reset to Default").onClick(async () => {
+            this.plugin.settings.customTemplate = DEFAULT_TEMPLATE;
+            await this.plugin.saveSettings();
+            if (this.templateEditor) {
+              setEditorValue(this.templateEditor, DEFAULT_TEMPLATE);
+            }
+          })
+        );
+    }
 
     // =================
     // Sync Filtering
@@ -286,7 +467,7 @@ export class HoarderSettingTab extends PluginSettingTab {
     containerEl.createEl("h3", { text: "Sync Filtering" });
     containerEl.createEl("div", {
       text: "Control which bookmarks are synchronized",
-      cls: "setting-item-description",
+      cls: "hoarder-section-description",
     });
 
     new Setting(containerEl)
@@ -365,7 +546,7 @@ export class HoarderSettingTab extends PluginSettingTab {
     containerEl.createEl("h3", { text: "Deletion Handling" });
     containerEl.createEl("div", {
       text: "Configure what happens when bookmarks are deleted in Karakeep",
-      cls: "setting-item-description",
+      cls: "hoarder-section-description",
     });
 
     const syncDeletionsToggle = new Setting(containerEl)
@@ -438,7 +619,7 @@ export class HoarderSettingTab extends PluginSettingTab {
     containerEl.createEl("h3", { text: "Archive Handling" });
     containerEl.createEl("div", {
       text: "Configure what happens when bookmarks are archived in Karakeep",
-      cls: "setting-item-description",
+      cls: "hoarder-section-description",
     });
 
     const handleArchivedToggle = new Setting(containerEl)
@@ -512,7 +693,7 @@ export class HoarderSettingTab extends PluginSettingTab {
     containerEl.createEl("h3", { text: "Manual Actions & Status" });
     containerEl.createEl("div", {
       text: "Manual sync controls and synchronization status",
-      cls: "setting-item-description",
+      cls: "hoarder-section-description",
     });
 
     // Add Sync Now button
@@ -538,7 +719,7 @@ export class HoarderSettingTab extends PluginSettingTab {
     if (this.plugin.settings.lastSyncTimestamp > 0) {
       containerEl.createEl("div", {
         text: `Last synced: ${new Date(this.plugin.settings.lastSyncTimestamp).toLocaleString()}`,
-        cls: "setting-item-description",
+        cls: "hoarder-section-description",
       });
     }
   }

--- a/src/template-editor.ts
+++ b/src/template-editor.ts
@@ -1,0 +1,129 @@
+import { RangeSetBuilder } from "@codemirror/state";
+import {
+  Decoration,
+  DecorationSet,
+  EditorView,
+  ViewPlugin,
+  ViewUpdate,
+} from "@codemirror/view";
+
+// Eta template tag highlighting via CM6 decorations
+const etaOutputTag = Decoration.mark({ class: "hoarder-eta-output" });
+const etaControlTag = Decoration.mark({ class: "hoarder-eta-control" });
+const yamlKey = Decoration.mark({ class: "hoarder-yaml-key" });
+const yamlFrontmatterDelim = Decoration.mark({ class: "hoarder-yaml-delim" });
+const markdownHeading = Decoration.mark({ class: "hoarder-md-heading" });
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const doc = view.state.doc;
+
+  for (let i = 1; i <= doc.lines; i++) {
+    const line = doc.line(i);
+    const text = line.text;
+
+    // YAML frontmatter delimiter
+    if (text === "---") {
+      builder.add(line.from, line.to, yamlFrontmatterDelim);
+      continue;
+    }
+
+    // Markdown headings
+    if (/^#{1,6}\s/.test(text)) {
+      builder.add(line.from, line.to, markdownHeading);
+      continue;
+    }
+
+    // YAML keys (word followed by colon at start of line, but not inside Eta tags)
+    const yamlMatch = text.match(/^([a-zA-Z_][a-zA-Z0-9_]*):/);
+    if (yamlMatch && !text.includes("<%")) {
+      builder.add(line.from, line.from + yamlMatch[1].length + 1, yamlKey);
+    }
+
+    // Eta tags within the line
+    const tagRegex = /<%[=_-]?[\s\S]*?[_-]?%>/g;
+    let match;
+    while ((match = tagRegex.exec(text)) !== null) {
+      const from = line.from + match.index;
+      const to = from + match[0].length;
+      const isOutput = match[0].startsWith("<%=");
+      builder.add(from, to, isOutput ? etaOutputTag : etaControlTag);
+    }
+  }
+
+  return builder.finish();
+}
+
+const etaHighlightPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.viewportChanged) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
+  },
+  { decorations: (v) => v.decorations }
+);
+
+const editorTheme = EditorView.theme({
+  "&": {
+    fontSize: "var(--font-ui-smaller)",
+    minHeight: "500px",
+    maxHeight: "600px",
+    border: "1px solid var(--background-modifier-border)",
+    borderRadius: "var(--radius-s)",
+    backgroundColor: "var(--background-primary)",
+  },
+  ".cm-scroller": {
+    overflow: "auto",
+    fontFamily: "var(--font-monospace)",
+  },
+  ".cm-content": {
+    padding: "var(--size-4-2)",
+  },
+  ".cm-gutters": {
+    backgroundColor: "var(--background-secondary)",
+    borderRight: "1px solid var(--background-modifier-border)",
+    color: "var(--text-faint)",
+  },
+  ".cm-cursor, .cm-dropCursor": {
+    borderLeftColor: "var(--text-normal)",
+    borderLeftWidth: "2px",
+  },
+  "&.cm-focused": {
+    outline: "none",
+    boxShadow: "0 0 0 2px var(--background-modifier-border-focus)",
+  },
+});
+
+export function createTemplateEditor(
+  container: HTMLElement,
+  initialValue: string,
+  onChange: (value: string) => void
+): EditorView {
+  const view = new EditorView({
+    doc: initialValue,
+    extensions: [
+      EditorView.lineWrapping,
+      editorTheme,
+      etaHighlightPlugin,
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          onChange(update.state.doc.toString());
+        }
+      }),
+    ],
+    parent: container,
+  });
+  return view;
+}
+
+export function setEditorValue(view: EditorView, value: string) {
+  view.dispatch({
+    changes: { from: 0, to: view.state.doc.length, insert: value },
+  });
+}

--- a/src/template-renderer.test.ts
+++ b/src/template-renderer.test.ts
@@ -3,6 +3,7 @@ import { escapeMarkdownPath, escapeYaml } from "./formatting-utils";
 import { HoarderBookmark, HoarderHighlight } from "./hoarder-client";
 import { DEFAULT_SETTINGS, HoarderSettings } from "./settings";
 import { sanitizeTags } from "./tag-utils";
+import { NOTE_BLOCK_START, NOTE_BLOCK_END } from "./template-renderer";
 import {
   DEFAULT_TEMPLATE,
   buildTemplateContext,
@@ -11,8 +12,8 @@ import {
   validateTemplate,
 } from "./template-renderer";
 
-// Reference implementation: the old hard-coded formatBookmarkAsMarkdown logic.
-// Used to verify parity with the DEFAULT_TEMPLATE.
+// Reference implementation of the expected DEFAULT_TEMPLATE output.
+// Used to verify the template produces the correct format.
 function referenceFormat(
   bookmark: HoarderBookmark,
   title: string,
@@ -382,6 +383,21 @@ describe("buildTemplateContext", () => {
     });
     const ctx = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings());
     expect(ctx.content_html).toBe("<p>Full page content</p>");
+  });
+
+  it("should wrap note in comment block markers", () => {
+    const bookmark = makeBookmark({ note: "My editable note" });
+    const ctx = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings());
+    expect(ctx.note).toBe("My editable note");
+    expect(ctx.noteBlock).toBe(
+      `${NOTE_BLOCK_START}\nMy editable note\n${NOTE_BLOCK_END}`
+    );
+  });
+
+  it("should handle empty note in noteBlock", () => {
+    const bookmark = makeBookmark({ note: "" });
+    const ctx = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings());
+    expect(ctx.noteBlock).toBe(`${NOTE_BLOCK_START}\n\n${NOTE_BLOCK_END}`);
   });
 });
 

--- a/src/template-renderer.test.ts
+++ b/src/template-renderer.test.ts
@@ -1,0 +1,486 @@
+import { AssetFrontmatter } from "./asset-handler";
+import { escapeMarkdownPath, escapeYaml } from "./formatting-utils";
+import { HoarderBookmark, HoarderHighlight } from "./hoarder-client";
+import { DEFAULT_SETTINGS, HoarderSettings } from "./settings";
+import { sanitizeTags } from "./tag-utils";
+import {
+  DEFAULT_TEMPLATE,
+  buildTemplateContext,
+  renderTemplate,
+  renderWithFallback,
+  validateTemplate,
+} from "./template-renderer";
+
+// Reference implementation: the old hard-coded formatBookmarkAsMarkdown logic.
+// Used to verify parity with the DEFAULT_TEMPLATE.
+function referenceFormat(
+  bookmark: HoarderBookmark,
+  title: string,
+  highlights: HoarderHighlight[],
+  assetContent: string,
+  assetsFm: AssetFrontmatter | null,
+  settings: HoarderSettings
+): string {
+  const url = bookmark.content.type === "link" ? bookmark.content.url : bookmark.content.sourceUrl;
+  const description =
+    bookmark.content.type === "link" ? bookmark.content.description : bookmark.content.text;
+  const rawTags = bookmark.tags.map((tag) => tag.name);
+  const tags = sanitizeTags(rawTags);
+
+  let assetsYaml = "";
+  if (assetsFm) {
+    const lines: string[] = [];
+    if (assetsFm.image) lines.push(`image: ${assetsFm.image}`);
+    if (assetsFm.banner) lines.push(`banner: ${assetsFm.banner}`);
+    if (assetsFm.screenshot) lines.push(`screenshot: ${assetsFm.screenshot}`);
+    if (assetsFm.full_page_archive) lines.push(`full_page_archive: ${assetsFm.full_page_archive}`);
+    if (assetsFm.pdf_archive) lines.push(`pdf_archive: ${assetsFm.pdf_archive}`);
+    if (assetsFm.video) lines.push(`video: ${assetsFm.video}`);
+    if (assetsFm.additional && assetsFm.additional.length > 0) {
+      lines.push("additional:");
+      for (const link of assetsFm.additional) {
+        lines.push(`  - ${link}`);
+      }
+    }
+    assetsYaml = lines.join("\n") + "\n";
+  }
+
+  const tagsYaml = tags.length > 0 ? `tags:\n  - ${tags.join("\n  - ")}\n` : "";
+
+  let content = `---
+bookmark_id: "${bookmark.id}"
+url: ${escapeYaml(url)}
+title: ${escapeYaml(title)}
+date: ${new Date(bookmark.createdAt).toISOString()}
+${bookmark.modifiedAt ? `modified: ${new Date(bookmark.modifiedAt).toISOString()}\n` : ""}${tagsYaml}note: ${escapeYaml(bookmark.note)}
+original_note: ${escapeYaml(bookmark.note)}
+summary: ${escapeYaml(bookmark.summary)}
+${assetsYaml}
+---
+
+# ${title}
+`;
+
+  content += assetContent;
+
+  if (bookmark.summary) {
+    content += `\n## Summary\n\n${bookmark.summary}\n`;
+  }
+
+  if (description) {
+    content += `\n## Description\n\n${description}\n`;
+  }
+
+  if (highlights && highlights.length > 0 && settings.syncHighlights) {
+    content += `\n## Highlights\n\n`;
+
+    const sortedHighlights = [...highlights].sort((a, b) => a.startOffset - b.startOffset);
+
+    for (const highlight of sortedHighlights) {
+      const date = new Date(highlight.createdAt).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+
+      content += `> [!karakeep-${highlight.color}] ${date}\n`;
+
+      const highlightLines = highlight.text.split("\n");
+      for (const line of highlightLines) {
+        content += `> ${line}\n`;
+      }
+
+      if (highlight.note && highlight.note.trim()) {
+        content += `>\n`;
+        const noteLines = highlight.note.split("\n");
+        for (let i = 0; i < noteLines.length; i++) {
+          if (i === 0) {
+            content += `> *Note: ${noteLines[i]}*\n`;
+          } else {
+            content += `> *${noteLines[i]}*\n`;
+          }
+        }
+      }
+
+      content += `\n`;
+    }
+  }
+
+  content += `\n## Notes\n\n${bookmark.note || ""}\n`;
+
+  if (url && bookmark.content.type !== "asset") {
+    content += `\n[Visit Link](${escapeMarkdownPath(url)})\n`;
+  }
+  const hoarderUrl = `${settings.apiEndpoint.replace("/api/v1", "/dashboard/preview")}/${bookmark.id}`;
+  content += `\n[View in Hoarder](${escapeMarkdownPath(hoarderUrl)})`;
+
+  return content;
+}
+
+function makeSettings(overrides: Partial<HoarderSettings> = {}): HoarderSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    apiEndpoint: "https://karakeep.example.com/api/v1",
+    syncHighlights: true,
+    ...overrides,
+  };
+}
+
+function makeBookmark(overrides: Partial<HoarderBookmark> = {}): HoarderBookmark {
+  return {
+    id: "bm-123",
+    createdAt: "2024-06-15T10:30:00.000Z",
+    modifiedAt: null,
+    archived: false,
+    favourited: false,
+    taggingStatus: "success",
+    note: null,
+    summary: null,
+    tags: [],
+    assets: [],
+    content: {
+      type: "link",
+      url: "https://example.com/article",
+      title: "Example Article",
+      description: "A great article about testing",
+    },
+    ...overrides,
+  };
+}
+
+function makeHighlight(overrides: Partial<HoarderHighlight> = {}): HoarderHighlight {
+  return {
+    id: "h-1",
+    bookmarkId: "bm-123",
+    startOffset: 0,
+    endOffset: 50,
+    color: "yellow",
+    text: "This is highlighted text",
+    note: "",
+    userId: "user-1",
+    createdAt: "2024-06-15T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function assertParity(
+  bookmark: HoarderBookmark,
+  title: string,
+  highlights: HoarderHighlight[],
+  assetContent: string,
+  assetsFm: AssetFrontmatter | null,
+  settings: HoarderSettings
+) {
+  const expected = referenceFormat(bookmark, title, highlights, assetContent, assetsFm, settings);
+  const context = buildTemplateContext(
+    bookmark,
+    title,
+    highlights,
+    assetContent,
+    assetsFm,
+    settings
+  );
+  const actual = renderTemplate(DEFAULT_TEMPLATE, context);
+  expect(actual).toBe(expected);
+}
+
+describe("DEFAULT_TEMPLATE parity", () => {
+  it("should match for a minimal link bookmark", () => {
+    const bookmark = makeBookmark({ summary: null, note: null });
+    const settings = makeSettings();
+    assertParity(bookmark, "Example Article", [], "", null, settings);
+  });
+
+  it("should match for a link bookmark with all fields", () => {
+    const bookmark = makeBookmark({
+      summary: "This is the AI summary",
+      note: "My personal notes here",
+      modifiedAt: "2024-07-01T08:00:00.000Z",
+      tags: [
+        { id: "t1", name: "javascript", attachedBy: "human" },
+        { id: "t2", name: "testing", attachedBy: "ai" },
+      ],
+    });
+    const settings = makeSettings();
+    assertParity(bookmark, "Example Article", [], "", null, settings);
+  });
+
+  it("should match for a text bookmark", () => {
+    const bookmark = makeBookmark({
+      content: {
+        type: "text",
+        text: "Some stored text content",
+        sourceUrl: null,
+      },
+    });
+    const settings = makeSettings();
+    assertParity(bookmark, "Text Note", [], "", null, settings);
+  });
+
+  it("should match for an asset bookmark (no visit link)", () => {
+    const bookmark = makeBookmark({
+      content: {
+        type: "asset",
+        assetType: "image",
+        assetId: "asset-1",
+        sourceUrl: "https://example.com/image.png",
+      },
+    });
+    const settings = makeSettings();
+    assertParity(
+      bookmark,
+      "My Image",
+      [],
+      "\n![My Image](https://example.com/image.png)\n",
+      null,
+      settings
+    );
+  });
+
+  it("should match for a bookmark with highlights", () => {
+    const bookmark = makeBookmark({ note: "My notes" });
+    const highlights = [
+      makeHighlight({
+        id: "h-1",
+        startOffset: 100,
+        text: "Second highlight",
+        color: "blue",
+        createdAt: "2024-06-16T10:00:00.000Z",
+      }),
+      makeHighlight({
+        id: "h-2",
+        startOffset: 10,
+        text: "First highlight",
+        color: "yellow",
+        note: "Important point",
+        createdAt: "2024-06-15T12:00:00.000Z",
+      }),
+    ];
+    const settings = makeSettings();
+    assertParity(bookmark, "Article with Highlights", highlights, "", null, settings);
+  });
+
+  it("should match for a bookmark with multi-line highlight text and notes", () => {
+    const bookmark = makeBookmark();
+    const highlights = [
+      makeHighlight({
+        text: "Line one\nLine two\nLine three",
+        note: "Note line one\nNote line two",
+      }),
+    ];
+    const settings = makeSettings();
+    assertParity(bookmark, "Multi-line", highlights, "", null, settings);
+  });
+
+  it("should match when highlights are disabled", () => {
+    const bookmark = makeBookmark();
+    const highlights = [makeHighlight()];
+    const settings = makeSettings({ syncHighlights: false });
+    assertParity(bookmark, "No Highlights", highlights, "", null, settings);
+  });
+
+  it("should match with asset frontmatter", () => {
+    const bookmark = makeBookmark();
+    const assetsFm: AssetFrontmatter = {
+      banner: '"[[Hoarder/attachments/img-1.jpg]]"',
+      screenshot: '"[[Hoarder/attachments/ss-1.png]]"',
+    };
+    const settings = makeSettings();
+    assertParity(bookmark, "With Assets", [], "\n![Banner](img-1.jpg)\n", assetsFm, settings);
+  });
+
+  it("should match with all asset frontmatter fields", () => {
+    const bookmark = makeBookmark();
+    const assetsFm: AssetFrontmatter = {
+      image: '"[[Hoarder/attachments/img.jpg]]"',
+      banner: '"[[Hoarder/attachments/banner.jpg]]"',
+      screenshot: '"[[Hoarder/attachments/ss.png]]"',
+      full_page_archive: '"[[Hoarder/attachments/archive.mhtml]]"',
+      pdf_archive: '"[[Hoarder/attachments/doc.pdf]]"',
+      video: '"[[Hoarder/attachments/vid.mp4]]"',
+      additional: ['"[[Hoarder/attachments/extra1.jpg]]"', '"[[Hoarder/attachments/extra2.png]]"'],
+    };
+    const settings = makeSettings();
+    assertParity(bookmark, "All Assets", [], "", assetsFm, settings);
+  });
+
+  it("should match with special YAML characters in fields", () => {
+    const bookmark = makeBookmark({
+      note: "Note with: colons and #hashtags",
+      summary: "Summary with [brackets] and {braces}",
+      content: {
+        type: "link",
+        url: "https://example.com/path?query=value&other=true",
+        title: "Title: With Special Characters!",
+        description: "Description with \"quotes\" and 'apostrophes'",
+      },
+    });
+    const settings = makeSettings();
+    assertParity(bookmark, "Title: With Special Characters!", [], "", null, settings);
+  });
+
+  it("should match with empty note and summary", () => {
+    const bookmark = makeBookmark({ note: "", summary: "" });
+    const settings = makeSettings();
+    assertParity(bookmark, "Empty Fields", [], "", null, settings);
+  });
+});
+
+describe("buildTemplateContext", () => {
+  it("should derive url from link content", () => {
+    const bookmark = makeBookmark({
+      content: { type: "link", url: "https://example.com" },
+    });
+    const ctx = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings());
+    expect(ctx.url).toBe("https://example.com");
+    expect(ctx.visit_link).toBe("https://example.com");
+  });
+
+  it("should derive url from asset sourceUrl", () => {
+    const bookmark = makeBookmark({
+      content: { type: "asset", sourceUrl: "https://example.com/img.png", assetType: "image" },
+    });
+    const ctx = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings());
+    expect(ctx.url).toBe("https://example.com/img.png");
+    expect(ctx.visit_link).toBeNull(); // asset type has no visit link
+  });
+
+  it("should sort highlights by startOffset", () => {
+    const highlights = [
+      makeHighlight({ id: "h-2", startOffset: 100 }),
+      makeHighlight({ id: "h-1", startOffset: 10 }),
+    ];
+    const ctx = buildTemplateContext(makeBookmark(), "Test", highlights, "", null, makeSettings());
+    expect(ctx.highlights[0].id).toBe("h-1");
+    expect(ctx.highlights[1].id).toBe("h-2");
+  });
+
+  it("should pre-escape YAML values", () => {
+    const bookmark = makeBookmark({
+      content: { type: "link", url: "https://example.com?q=1&r=2" },
+      note: "Note with: colons",
+    });
+    const ctx = buildTemplateContext(bookmark, "Simple Title", [], "", null, makeSettings());
+    expect(ctx.yaml.title).toBe("Simple Title");
+    expect(ctx.yaml.note).toContain("Note with");
+    expect(ctx.yaml.url).toBeTruthy();
+  });
+
+  it("should format highlight dates", () => {
+    const highlights = [makeHighlight({ createdAt: "2024-01-15T10:30:00.000Z" })];
+    const ctx = buildTemplateContext(makeBookmark(), "Test", highlights, "", null, makeSettings());
+    expect(ctx.highlights[0].date).toBe("January 15, 2024");
+  });
+
+  it("should expose content_html", () => {
+    const bookmark = makeBookmark({
+      content: {
+        type: "link",
+        url: "https://example.com",
+        htmlContent: "<p>Full page content</p>",
+      },
+    });
+    const ctx = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings());
+    expect(ctx.content_html).toBe("<p>Full page content</p>");
+  });
+});
+
+describe("validateTemplate", () => {
+  it("should accept valid Eta syntax", () => {
+    const result = validateTemplate("<%= it.title %>");
+    expect(result.valid).toBe(true);
+  });
+
+  it("should accept the DEFAULT_TEMPLATE with no warnings", () => {
+    const result = validateTemplate(DEFAULT_TEMPLATE);
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it("should reject invalid syntax", () => {
+    const result = validateTemplate("<% if (it.title { %>");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Syntax error");
+  });
+
+  it("should reject templates that crash at render time", () => {
+    const result = validateTemplate("<%= it.nonExistent.deep.property %>");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Render error");
+  });
+
+  it("should warn when frontmatter delimiters are missing", () => {
+    const result = validateTemplate("# <%= it.title %>\n<%= it.note %>");
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toContain(
+      "Template output is missing YAML frontmatter (--- delimiters)"
+    );
+  });
+
+  it("should warn when bookmark_id is missing", () => {
+    const result = validateTemplate("---\ntitle: test\n---\n# Test");
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("bookmark_id"),
+      ])
+    );
+  });
+
+  it("should warn when original_note is missing", () => {
+    const result = validateTemplate(
+      "---\nbookmark_id: test\n---\n# Test\n\n## Notes\n\ntest"
+    );
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("original_note"),
+      ])
+    );
+  });
+
+  it("should warn when Notes section is missing", () => {
+    const result = validateTemplate(
+      "---\nbookmark_id: test\noriginal_note: test\n---\n# Test"
+    );
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("## Notes"),
+      ])
+    );
+  });
+});
+
+describe("renderWithFallback", () => {
+  it("should fall back to DEFAULT_TEMPLATE on error", () => {
+    const bookmark = makeBookmark();
+    const context = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings());
+
+    // This template references an undefined function, which will throw at render time
+    const brokenTemplate = "<%= it.nonExistentFunction() %>";
+    const result = renderWithFallback(brokenTemplate, context);
+
+    // Should produce valid output from the default template
+    expect(result).toContain("bookmark_id");
+    expect(result).toContain("Test");
+  });
+});
+
+describe("custom template", () => {
+  it("should render a simple custom template", () => {
+    const bookmark = makeBookmark({ note: "My note" });
+    const context = buildTemplateContext(bookmark, "My Title", [], "", null, makeSettings());
+    const customTemplate = `# <%= it.title %>\n\n<%= it.note %>`;
+    const result = renderTemplate(customTemplate, context);
+    expect(result).toBe("# My Title\n\nMy note");
+  });
+
+  it("should provide helper functions in context", () => {
+    const bookmark = makeBookmark();
+    const context = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings());
+    const template = `<%= it.escapeYaml("value: with colons") %>`;
+    const result = renderTemplate(template, context);
+    expect(result).toContain("value");
+  });
+});

--- a/src/template-renderer.ts
+++ b/src/template-renderer.ts
@@ -1,0 +1,290 @@
+import { Eta } from "eta";
+
+import { AssetFrontmatter } from "./asset-handler";
+import { escapeMarkdownPath, escapeYaml, sanitizeHtml } from "./formatting-utils";
+import { HoarderBookmark, HoarderHighlight } from "./hoarder-client";
+import { HoarderSettings } from "./settings";
+import { sanitizeTags } from "./tag-utils";
+
+export interface TemplateContext {
+  bookmark_id: string;
+  title: string;
+  url: string | undefined | null;
+  description: string | undefined | null;
+  created_at: string;
+  modified_at: string | null;
+  note: string;
+  summary: string | undefined | null;
+  archived: boolean;
+  favourited: boolean;
+  content_type: string;
+  content_html: string | undefined | null;
+  tags: string[];
+  yaml: {
+    url: string;
+    title: string;
+    note: string;
+    summary: string;
+  };
+  assets: {
+    content: string;
+    image?: string;
+    banner?: string;
+    screenshot?: string;
+    full_page_archive?: string;
+    pdf_archive?: string;
+    video?: string;
+    additional?: string[];
+  };
+  highlights: Array<{
+    id: string;
+    color: string;
+    text: string;
+    note: string;
+    date: string;
+    created_at: string;
+  }>;
+  hoarder_url: string;
+  visit_link: string | null;
+  sync_highlights: boolean;
+  escapeYaml: (str: string | null | undefined) => string;
+  escapeMarkdownPath: (path: string) => string;
+  formatDate: (iso: string) => string;
+}
+
+// The default template reproduces the exact output of the original formatBookmarkAsMarkdown().
+// Whitespace is critical — every newline and space must match.
+export const DEFAULT_TEMPLATE = `---
+bookmark_id: "<%= it.bookmark_id %>"
+url: <%= it.yaml.url %>
+title: <%= it.yaml.title %>
+date: <%= it.created_at %>
+<% if (it.modified_at) { %>modified: <%= it.modified_at %>
+<% } %><% if (it.tags.length > 0) { %>tags:
+<% it.tags.forEach(function(tag) { %>  - <%= tag %>
+<% }) %><% } %>note: <%= it.yaml.note %>
+original_note: <%= it.yaml.note %>
+summary: <%= it.yaml.summary %>
+<% if (it.assets.image) { %>image: <%= it.assets.image %>
+<% } %><% if (it.assets.banner) { %>banner: <%= it.assets.banner %>
+<% } %><% if (it.assets.screenshot) { %>screenshot: <%= it.assets.screenshot %>
+<% } %><% if (it.assets.full_page_archive) { %>full_page_archive: <%= it.assets.full_page_archive %>
+<% } %><% if (it.assets.pdf_archive) { %>pdf_archive: <%= it.assets.pdf_archive %>
+<% } %><% if (it.assets.video) { %>video: <%= it.assets.video %>
+<% } %><% if (it.assets.additional && it.assets.additional.length > 0) { %>additional:
+<% it.assets.additional.forEach(function(link) { %>  - <%= link %>
+<% }) %><% } %>
+---
+
+# <%= it.title %>
+<%= it.assets.content %><% if (it.summary) { %>
+## Summary
+
+<%= it.summary %>
+<% } %><% if (it.description) { %>
+## Description
+
+<%= it.description %>
+<% } %><% if (it.highlights.length > 0 && it.sync_highlights) { %>
+## Highlights
+
+<% it.highlights.forEach(function(h) { %>> [!karakeep-<%= h.color %>] <%= h.date %>
+<%= h.text.split('\\n').map(function(line) { return '> ' + line }).join('\\n') %>
+<% if (h.note && h.note.trim()) { %>>
+<%= h.note.split('\\n').map(function(line, i) { return i === 0 ? '> *Note: ' + line + '*' : '> *' + line + '*' }).join('\\n') %>
+<% } %>
+<% }) %><% } %>
+## Notes
+
+<%= it.note %>
+<% if (it.visit_link) { %>
+[Visit Link](<%= it.visit_link %>)
+<% } %>
+[View in Hoarder](<%= it.escapeMarkdownPath(it.hoarder_url) %>)`;
+
+const eta = new Eta({ autoEscape: false, autoTrim: false });
+
+// Cache compiled templates to avoid recompilation on every render
+const compiledTemplateCache = new Map<string, ReturnType<typeof eta.compile>>();
+
+function getCompiledTemplate(templateString: string): ReturnType<typeof eta.compile> {
+  let compiled = compiledTemplateCache.get(templateString);
+  if (!compiled) {
+    compiled = eta.compile(templateString);
+    compiledTemplateCache.set(templateString, compiled);
+  }
+  return compiled;
+}
+
+function formatHighlightDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function buildTemplateContext(
+  bookmark: HoarderBookmark,
+  title: string,
+  highlights: HoarderHighlight[] | undefined,
+  assetContent: string,
+  assetsFm: AssetFrontmatter | null,
+  settings: HoarderSettings
+): TemplateContext {
+  const url = bookmark.content.type === "link" ? bookmark.content.url : bookmark.content.sourceUrl;
+  const description =
+    bookmark.content.type === "link" ? bookmark.content.description : bookmark.content.text;
+  const rawTags = bookmark.tags.map((tag) => tag.name);
+  const tags = sanitizeTags(rawTags);
+
+  // Only sort and format highlights when they'll actually be rendered
+  const sortedHighlights =
+    highlights && highlights.length > 0 && settings.syncHighlights
+      ? [...highlights].sort((a, b) => a.startOffset - b.startOffset)
+      : [];
+
+  const hoarderUrl = `${settings.apiEndpoint.replace("/api/v1", "/dashboard/preview")}/${bookmark.id}`;
+
+  return {
+    bookmark_id: bookmark.id,
+    title,
+    url,
+    description,
+    created_at: new Date(bookmark.createdAt).toISOString(),
+    modified_at: bookmark.modifiedAt ? new Date(bookmark.modifiedAt).toISOString() : null,
+    note: bookmark.note || "",
+    summary: bookmark.summary,
+    archived: bookmark.archived,
+    favourited: bookmark.favourited,
+    content_type: bookmark.content.type,
+    content_html: bookmark.content.htmlContent ? sanitizeHtml(bookmark.content.htmlContent) : null,
+    tags,
+    yaml: {
+      url: escapeYaml(url),
+      title: escapeYaml(title),
+      note: escapeYaml(bookmark.note),
+      summary: escapeYaml(bookmark.summary),
+    },
+    assets: {
+      content: assetContent,
+      image: assetsFm?.image,
+      banner: assetsFm?.banner,
+      screenshot: assetsFm?.screenshot,
+      full_page_archive: assetsFm?.full_page_archive,
+      pdf_archive: assetsFm?.pdf_archive,
+      video: assetsFm?.video,
+      additional: assetsFm?.additional,
+    },
+    highlights: sortedHighlights.map((h) => ({
+      id: h.id,
+      color: h.color,
+      text: h.text,
+      note: h.note,
+      date: formatHighlightDate(h.createdAt),
+      created_at: h.createdAt,
+    })),
+    hoarder_url: hoarderUrl,
+    visit_link: url && bookmark.content.type !== "asset" ? escapeMarkdownPath(url) : null,
+    sync_highlights: settings.syncHighlights,
+    escapeYaml,
+    escapeMarkdownPath,
+    formatDate: formatHighlightDate,
+  };
+}
+
+export function renderTemplate(templateString: string, context: TemplateContext): string {
+  const compiled = getCompiledTemplate(templateString);
+  return eta.render(compiled, context);
+}
+
+export function renderWithFallback(templateString: string, context: TemplateContext): string {
+  try {
+    return renderTemplate(templateString, context);
+  } catch (error) {
+    console.error("[Hoarder] Template rendering failed, using default:", error);
+    return renderTemplate(DEFAULT_TEMPLATE, context);
+  }
+}
+
+// Sample context used for test-rendering during validation
+const SAMPLE_CONTEXT: TemplateContext = {
+  bookmark_id: "sample-id",
+  title: "Sample Bookmark",
+  url: "https://example.com",
+  description: "A sample description",
+  created_at: "2024-01-15T10:30:00.000Z",
+  modified_at: null,
+  note: "",
+  summary: "A sample summary",
+  archived: false,
+  favourited: false,
+  content_type: "link",
+  content_html: null,
+  tags: ["sample-tag"],
+  yaml: {
+    url: "https://example.com",
+    title: "Sample Bookmark",
+    note: "",
+    summary: "A sample summary",
+  },
+  assets: { content: "" },
+  highlights: [
+    {
+      id: "h-1",
+      color: "yellow",
+      text: "Sample highlight",
+      note: "",
+      date: "January 15, 2024",
+      created_at: "2024-01-15T12:00:00.000Z",
+    },
+  ],
+  hoarder_url: "https://example.com/dashboard/preview/sample-id",
+  visit_link: "https://example.com",
+  sync_highlights: true,
+  escapeYaml,
+  escapeMarkdownPath,
+  formatDate: formatHighlightDate,
+};
+
+export function validateTemplate(
+  templateString: string
+): { valid: boolean; error?: string; warnings?: string[] } {
+  // 1. Check syntax (compilation)
+  try {
+    eta.compile(templateString);
+  } catch (error: any) {
+    return { valid: false, error: `Syntax error: ${error.message || String(error)}` };
+  }
+
+  // 2. Test render with sample data
+  let rendered: string;
+  try {
+    rendered = renderTemplate(templateString, SAMPLE_CONTEXT);
+  } catch (error: any) {
+    return { valid: false, error: `Render error: ${error.message || String(error)}` };
+  }
+
+  // 3. Check output structure
+  const warnings: string[] = [];
+
+  if (!rendered.startsWith("---\n") || !rendered.includes("\n---\n")) {
+    warnings.push("Template output is missing YAML frontmatter (--- delimiters)");
+  }
+
+  if (!rendered.includes("bookmark_id:")) {
+    warnings.push("Template output is missing bookmark_id in frontmatter");
+  }
+
+  if (!rendered.includes("original_note:")) {
+    warnings.push(
+      "Template output is missing original_note — bi-directional sync will not work"
+    );
+  }
+
+  if (!/## Notes\b/.test(rendered)) {
+    warnings.push("Template output is missing ## Notes section — bi-directional sync will not work");
+  }
+
+  return { valid: true, warnings: warnings.length > 0 ? warnings : undefined };
+}

--- a/src/template-renderer.ts
+++ b/src/template-renderer.ts
@@ -14,6 +14,7 @@ export interface TemplateContext {
   created_at: string;
   modified_at: string | null;
   note: string;
+  noteBlock: string;
   summary: string | undefined | null;
   archived: boolean;
   favourited: boolean;
@@ -102,6 +103,13 @@ summary: <%= it.yaml.summary %>
 <% } %>
 [View in Hoarder](<%= it.escapeMarkdownPath(it.hoarder_url) %>)`;
 
+export const NOTE_BLOCK_START = "<!-- karakeep:notes -->";
+export const NOTE_BLOCK_END = "<!-- /karakeep:notes -->";
+
+function wrapNoteBlock(note: string): string {
+  return `${NOTE_BLOCK_START}\n${note}\n${NOTE_BLOCK_END}`;
+}
+
 const eta = new Eta({ autoEscape: false, autoTrim: false });
 
 // Cache compiled templates to avoid recompilation on every render
@@ -154,6 +162,7 @@ export function buildTemplateContext(
     created_at: new Date(bookmark.createdAt).toISOString(),
     modified_at: bookmark.modifiedAt ? new Date(bookmark.modifiedAt).toISOString() : null,
     note: bookmark.note || "",
+    noteBlock: wrapNoteBlock(bookmark.note || ""),
     summary: bookmark.summary,
     archived: bookmark.archived,
     favourited: bookmark.favourited,
@@ -216,6 +225,7 @@ const SAMPLE_CONTEXT: TemplateContext = {
   created_at: "2024-01-15T10:30:00.000Z",
   modified_at: null,
   note: "",
+  noteBlock: wrapNoteBlock(""),
   summary: "A sample summary",
   archived: false,
   favourited: false,

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,19 @@
+/* Settings panel normalization — override theme card styles */
+.hoarder-settings h3 {
+  margin-left: 0 !important;
+  padding-left: 0 !important;
+}
+
+.hoarder-settings .setting-item {
+  border: none !important;
+  border-top: 1px solid var(--background-modifier-border) !important;
+  border-radius: 0 !important;
+  background: none !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  padding: var(--size-4-3) 0 !important;
+}
+
 .hoarder-wide-input {
   width: var(--size-4-100);
 }
@@ -40,8 +56,89 @@
   background: var(--background-modifier-hover);
 }
 
-.setting-item-description {
+.hoarder-section-description {
   margin-bottom: var(--size-4-4);
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+}
+
+.hoarder-template-editor {
+  width: 100%;
+  margin-bottom: var(--size-4-4);
+}
+
+.hoarder-template-reference {
+  margin-bottom: var(--size-4-3);
+  font-size: var(--font-ui-smaller);
+  color: var(--text-muted);
+}
+
+.hoarder-template-reference summary {
+  cursor: pointer;
+  color: var(--text-normal);
+  font-weight: var(--font-medium);
+}
+
+.hoarder-template-ref-content {
+  margin-top: var(--size-4-2);
+  padding: var(--size-4-2) var(--size-4-3);
+  background: var(--background-secondary);
+  border-radius: var(--radius-s);
+  white-space: pre-line;
+  line-height: 1.8;
+}
+
+.hoarder-template-ref-content code {
+  background: var(--background-modifier-code);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: var(--font-ui-smaller);
+}
+
+.hoarder-template-warnings {
+  margin-top: var(--size-4-2);
+}
+
+.hoarder-template-warning {
+  color: var(--color-orange);
+  font-size: var(--font-ui-smaller);
+  padding: var(--size-2-1) 0;
+}
+
+.hoarder-template-error {
+  color: var(--text-error);
+  font-size: var(--font-ui-smaller);
+  padding: var(--size-2-1) 0;
+}
+
+/* Eta output tags: <%= ... %> */
+.hoarder-eta-output {
+  color: var(--color-green);
+  background-color: rgba(var(--color-green-rgb), 0.1);
+  border-radius: 2px;
+}
+
+/* Eta control tags: <% ... %> */
+.hoarder-eta-control {
+  color: var(--color-purple);
+  background-color: rgba(var(--color-purple-rgb), 0.1);
+  border-radius: 2px;
+}
+
+/* YAML keys */
+.hoarder-yaml-key {
+  color: var(--color-cyan);
+}
+
+/* YAML frontmatter delimiters --- */
+.hoarder-yaml-delim {
+  color: var(--text-faint);
+}
+
+/* Markdown headings */
+.hoarder-md-heading {
+  color: var(--color-orange);
+  font-weight: var(--font-bold);
 }
 
 /* Karakeep Highlight Callouts */


### PR DESCRIPTION
## Summary

  - Custom note templates — full Eta template engine support for customizing bookmark note layout (frontmatter fields, body sections, ordering). Default template is a drop-in replacement for the previous
  hard-coded formatter (zero breaking changes).
  - CodeMirror 6 template editor — syntax-highlighted template editor in settings using Obsidian's already-bundled CM6 (zero bundle overhead). Highlights Eta tags, YAML keys, and Markdown headings.
  - Semantic sync comparison — file rewrites no longer trigger on format-only changes (whitespace, field reordering). Frontmatter is parsed and compared key-by-key; mtime is only updated when content actually
   differs. Closes #19.
  - Correct attachment extensions — asset file extensions are now resolved from the HTTP Content-Type header (priority), then asset label, then URL. Per-type download toggles for banners, screenshots, PDF
  archives, and full-page archives. Closes #36.
  - Robust note extraction — 3-tier fallback for bi-directional note sync: comment-delimited block (<!-- karakeep:notes -->) → ## Notes section → frontmatter note field. Custom templates can use it.noteBlock
  for template-independent note editing. Partially addresses #22.
  - content_html template variable — crawled HTML content exposed as it.content_html in templates; only fetched from the API when the active template references the variable.
  - HTML sanitization — content_html strips scripts, iframes, event handlers, and javascript: URLs before exposure to templates.
  - Settings panel cleanup — fixed indented section headers and per-theme bordered setting cards; scoped all plugin CSS to .hoarder-settings.

##  Breaking changes

  None for default users. The default template reproduces the previous formatter output character-for-character.

  Users who have already added a ## Notes section above other sections in a custom layout: the ## Notes extractor now strips trailing footer links rather than truncating at any [-prefixed line, which may
  change note boundaries in edge cases.