### PR TITLE
chore: Increment Obsidian Plugin Version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "hoarder-sync",
     "name": "Hoarder Sync",
-    "version": "1.12.0",
+    "version": "2.0.0",
     "minAppVersion": "1.7.0",
     "description": "Sync your Hoarder bookmarks",
     "author": "Jordan Hofker",


### PR DESCRIPTION
<img width="611" height="86" alt="image" src="https://github.com/user-attachments/assets/3f4872f1-aa0c-45db-894b-2c865a27b629" />

despite being updated 4 days ago, the reported version number is still 1.12.0

~~realized this sounded passive aggressive after writing the above - apologies for that, it was not intended~~

congrats on the 2.0 update btw, that's huge and I'm excited to use it :)