### PR TITLE
feat: add content.author as available template field

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,85 @@ When "Handle archived bookmarks" is enabled, the plugin separately handles bookm
 
 This gives you fine-grained control over how your Obsidian vault reflects the state of your Karakeep bookmarks.
 
+## Custom Templates
+
+The plugin uses [Eta](https://eta.js.org/) templates to render bookmark notes. You can customize the template in Settings → Hoarder Sync → Template.
+
+Use `<%= it.variable %>` for output and `<% if (condition) { %>` for logic.
+
+### Available Variables
+
+**Bookmark fields**
+
+| Variable | Type | Description |
+|---|---|---|
+| `it.bookmark_id` | `string` | Unique bookmark ID |
+| `it.title` | `string` | Bookmark title |
+| `it.url` | `string \| null` | Source URL |
+| `it.description` | `string \| null` | Page description or text excerpt |
+| `it.author` | `string \| null` | Author from page metadata |
+| `it.note` | `string` | Your note (raw text) |
+| `it.noteBlock` | `string` | Note wrapped in sync comment markers |
+| `it.summary` | `string \| null` | AI-generated summary |
+| `it.created_at` | `string` | ISO 8601 creation date |
+| `it.modified_at` | `string \| null` | ISO 8601 modification date |
+| `it.content_type` | `string` | `"link"`, `"text"`, or `"asset"` |
+| `it.content_html` | `string \| null` | Raw HTML content (sanitized) |
+| `it.archived` | `boolean` | Whether bookmark is archived |
+| `it.favourited` | `boolean` | Whether bookmark is favorited |
+| `it.tags` | `string[]` | Tag names |
+| `it.hoarder_url` | `string` | Link to bookmark in Karakeep |
+| `it.visit_link` | `string \| null` | Escaped URL for Markdown links |
+| `it.sync_highlights` | `boolean` | Whether highlight sync is enabled |
+
+**Pre-escaped for YAML frontmatter**
+
+| Variable | Description |
+|---|---|
+| `it.yaml.url` | URL safe for YAML |
+| `it.yaml.title` | Title safe for YAML |
+| `it.yaml.note` | Note safe for YAML |
+| `it.yaml.summary` | Summary safe for YAML |
+
+**Assets**
+
+| Variable | Description |
+|---|---|
+| `it.assets.content` | Rendered asset embeds |
+| `it.assets.image` | Image asset path |
+| `it.assets.banner` | Banner image path |
+| `it.assets.screenshot` | Screenshot path |
+| `it.assets.full_page_archive` | Full-page archive path |
+| `it.assets.pdf_archive` | PDF archive path |
+| `it.assets.video` | Video asset path |
+| `it.assets.additional` | `string[]` of additional asset paths |
+
+**Highlights** (`it.highlights` array, each item has:)
+
+| Property | Description |
+|---|---|
+| `.id` | Highlight ID |
+| `.color` | `"yellow"`, `"red"`, `"green"`, or `"blue"` |
+| `.text` | Highlighted text |
+| `.note` | Note on the highlight |
+| `.date` | Formatted date string |
+| `.created_at` | ISO 8601 creation date |
+
+**Helper functions**
+
+| Function | Description |
+|---|---|
+| `it.escapeYaml(str)` | Escape a string for YAML frontmatter |
+| `it.escapeMarkdownPath(path)` | Escape a path for Markdown links |
+| `it.formatDate(iso)` | Format an ISO date as a readable string |
+
+### Example
+
+```
+<% if (it.author) { %>author: <%= it.escapeYaml(it.author) %>
+<% } %>
+```
+
 ## Development
 
 1. Clone this repository

--- a/src/hoarder-client.ts
+++ b/src/hoarder-client.ts
@@ -32,6 +32,7 @@ export interface HoarderBookmarkContent {
   favicon?: string | null;
   htmlContent?: string | null;
   crawledAt?: string | null;
+  author?: string | null;
   text?: string;
   sourceUrl?: string | null;
   assetType?: "image" | "pdf";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -388,7 +388,7 @@ export class HoarderSettingTab extends PluginSettingTab {
 <code>it.note</code> (raw text) <code>it.noteBlock</code> (editable, wrapped in comment markers)
 <code>it.summary</code> <code>it.created_at</code> <code>it.modified_at</code>
 <code>it.content_type</code> ("link", "text", "asset") <code>it.content_html</code>
-<code>it.archived</code> <code>it.favourited</code>
+<code>it.author</code> <code>it.archived</code> <code>it.favourited</code>
 <code>it.tags</code> (string array) <code>it.hoarder_url</code> <code>it.visit_link</code>
 
 <strong>Pre-escaped for YAML frontmatter</strong>

--- a/src/template-renderer.ts
+++ b/src/template-renderer.ts
@@ -20,6 +20,7 @@ export interface TemplateContext {
   favourited: boolean;
   content_type: string;
   content_html: string | undefined | null;
+  author: string | undefined | null;
   tags: string[];
   yaml: {
     url: string;
@@ -168,6 +169,7 @@ export function buildTemplateContext(
     favourited: bookmark.favourited,
     content_type: bookmark.content.type,
     content_html: bookmark.content.htmlContent ? sanitizeHtml(bookmark.content.htmlContent) : null,
+    author: bookmark.content.author ?? null,
     tags,
     yaml: {
       url: escapeYaml(url),
@@ -231,6 +233,7 @@ const SAMPLE_CONTEXT: TemplateContext = {
   favourited: false,
   content_type: "link",
   content_html: null,
+  author: "Sample Author",
   tags: ["sample-tag"],
   yaml: {
     url: "https://example.com",


### PR DESCRIPTION
## Summary

- Adds `it.author` to the Eta template context, mapped from `bookmark.content.author` in the Karakeep API response
- Documents all available template variables in a new **Custom Templates** section in the README

## Test plan

- [ ] Verify `it.author` renders correctly when author metadata is present on a bookmark
- [ ] Verify `it.author` is `null` (and conditional `<% if (it.author) { %>` works) when no author is available
- [ ] Confirm template validation still passes with the updated `SAMPLE_CONTEXT`
- [ ] All 456 existing tests pass (`npm test`)