### PR TITLE
Fix Obsidian scorecard review issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "22.x"
 
@@ -26,6 +30,14 @@ jobs:
       - name: Build plugin
         run: npm run build
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/main.js
+            dist/manifest.json
+            dist/styles.css
+
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,4 +46,5 @@ jobs:
 
           gh release create "$tag" \
             --title="$tag" \
+            --generate-notes \
             dist/main.js dist/manifest.json dist/styles.css

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Contributions are welcome! Please open an issue before submitting a PR for significant changes.
+
+## Development Setup
+
+```bash
+git clone https://github.com/jhofker/obsidian-hoarder
+cd obsidian-hoarder
+npm install
+```
+
+## Building
+
+```bash
+npm run build        # production build
+npm run dev          # watch mode
+```
+
+## Testing
+
+```bash
+npm test             # run tests
+npm run test:watch   # watch mode
+npm run test:coverage
+```
+
+## Pull Requests
+
+- Keep changes focused and well-described
+- Add or update tests for new behavior
+- Run `npm run build` before submitting to ensure it compiles

--- a/README.md
+++ b/README.md
@@ -80,6 +80,85 @@ When "Handle archived bookmarks" is enabled, the plugin separately handles bookm
 
 This gives you fine-grained control over how your Obsidian vault reflects the state of your Karakeep bookmarks.
 
+## Custom Templates
+
+The plugin uses [Eta](https://eta.js.org/) templates to render bookmark notes. You can customize the template in Settings → Hoarder Sync → Template.
+
+Use `<%= it.variable %>` for output and `<% if (condition) { %>` for logic.
+
+### Available Variables
+
+**Bookmark fields**
+
+| Variable | Type | Description |
+|---|---|---|
+| `it.bookmark_id` | `string` | Unique bookmark ID |
+| `it.title` | `string` | Bookmark title |
+| `it.url` | `string \| null` | Source URL |
+| `it.description` | `string \| null` | Page description or text excerpt |
+| `it.author` | `string \| null` | Author from page metadata |
+| `it.note` | `string` | Your note (raw text) |
+| `it.noteBlock` | `string` | Note wrapped in sync comment markers |
+| `it.summary` | `string \| null` | AI-generated summary |
+| `it.created_at` | `string` | ISO 8601 creation date |
+| `it.modified_at` | `string \| null` | ISO 8601 modification date |
+| `it.content_type` | `string` | `"link"`, `"text"`, or `"asset"` |
+| `it.content_html` | `string \| null` | Raw HTML content (sanitized) |
+| `it.archived` | `boolean` | Whether bookmark is archived |
+| `it.favourited` | `boolean` | Whether bookmark is favorited |
+| `it.tags` | `string[]` | Tag names |
+| `it.hoarder_url` | `string` | Link to bookmark in Karakeep |
+| `it.visit_link` | `string \| null` | Escaped URL for Markdown links |
+| `it.sync_highlights` | `boolean` | Whether highlight sync is enabled |
+
+**Pre-escaped for YAML frontmatter**
+
+| Variable | Description |
+|---|---|
+| `it.yaml.url` | URL safe for YAML |
+| `it.yaml.title` | Title safe for YAML |
+| `it.yaml.note` | Note safe for YAML |
+| `it.yaml.summary` | Summary safe for YAML |
+
+**Assets**
+
+| Variable | Description |
+|---|---|
+| `it.assets.content` | Rendered asset embeds |
+| `it.assets.image` | Image asset path |
+| `it.assets.banner` | Banner image path |
+| `it.assets.screenshot` | Screenshot path |
+| `it.assets.full_page_archive` | Full-page archive path |
+| `it.assets.pdf_archive` | PDF archive path |
+| `it.assets.video` | Video asset path |
+| `it.assets.additional` | `string[]` of additional asset paths |
+
+**Highlights** (`it.highlights` array, each item has:)
+
+| Property | Description |
+|---|---|
+| `.id` | Highlight ID |
+| `.color` | `"yellow"`, `"red"`, `"green"`, or `"blue"` |
+| `.text` | Highlighted text |
+| `.note` | Note on the highlight |
+| `.date` | Formatted date string |
+| `.created_at` | ISO 8601 creation date |
+
+**Helper functions**
+
+| Function | Description |
+|---|---|
+| `it.escapeYaml(str)` | Escape a string for YAML frontmatter |
+| `it.escapeMarkdownPath(path)` | Escape a path for Markdown links |
+| `it.formatDate(iso)` | Format an ISO date as a readable string |
+
+### Example
+
+```
+<% if (it.author) { %>author: <%= it.escapeYaml(it.author) %>
+<% } %>
+```
+
 ## Development
 
 1. Clone this repository

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import process from "process";
-import builtins from "builtin-modules";
+import { builtinModules } from "module";
 import fs from "fs/promises";
 import path from "path";
 
@@ -42,7 +42,8 @@ const context = await esbuild.context({
         '@lezer/common',
         '@lezer/highlight',
         '@lezer/lr',
-        ...builtins],
+        ...builtinModules,
+        ...builtinModules.map((m) => `node:${m}`)],
     format: 'cjs',
     target: 'es2018',
     logLevel: "info",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "hoarder-sync",
     "name": "Karakeep (Hoarder) Sync",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "minAppVersion": "1.7.0",
     "description": "Sync your Karakeep (Hoarder) bookmarks",
     "author": "Jordan Hofker",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "Karakeep (Hoarder) Sync",
     "version": "2.0.2",
     "minAppVersion": "1.7.0",
-    "description": "Sync your Karakeep (Hoarder) bookmarks",
+    "description": "Sync your Karakeep (Hoarder) bookmarks.",
     "author": "Jordan Hofker",
     "isDesktopOnly": false
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@types/node": "^25",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "builtin-modules": "^5",
     "esbuild": "^0.27",
     "jest": "^30",
     "obsidian": "^1.12",
@@ -39,6 +38,8 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@codemirror/state": "^6",
+    "@codemirror/view": "^6",
     "eta": "^4.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-hoarder",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Sync your Karakeep (Hoarder) bookmarks with Obsidian",
   "main": "dist/main.js",
   "scripts": {

--- a/src/asset-handler.ts
+++ b/src/asset-handler.ts
@@ -1,4 +1,4 @@
-import { App } from "obsidian";
+import { App, requestUrl } from "obsidian";
 
 import { escapeAltText, escapeMarkdownPath } from "./formatting-utils";
 import { HoarderApiClient, HoarderBookmark } from "./hoarder-client";
@@ -155,11 +155,11 @@ async function downloadAssetFile(
         headers["Authorization"] = `Bearer ${settings.apiKey}`;
       }
 
-      const response = await fetch(url, { headers });
-      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const response = await requestUrl({ url, headers });
+      if (response.status >= 400) throw new Error(`HTTP error! status: ${response.status}`);
 
-      buffer = await response.arrayBuffer();
-      contentType = response.headers.get("content-type");
+      buffer = response.arrayBuffer;
+      contentType = response.headers["content-type"] || null;
     }
 
     const extension = resolveAssetExtension(contentType, assetLabel, url);

--- a/src/formatting-utils.ts
+++ b/src/formatting-utils.ts
@@ -11,7 +11,7 @@ export function escapeYaml(str: string | null | undefined): string {
   if (!str) return "";
 
   // If string contains newlines or special characters, use block scalar
-  if (str.includes("\n") || /[:#{}\[\],&*?|<>=!%@`]/.test(str)) {
+  if (str.includes("\n") || /[:#{}[\],&*?|<>=!%@`]/.test(str)) {
     return `|\n  ${str.replace(/\n/g, "\n  ")}`;
   }
 
@@ -21,7 +21,7 @@ export function escapeYaml(str: string | null | undefined): string {
   }
 
   if (str.includes("'") || /^[ \t]|[ \t]$/.test(str)) {
-    return `"${str.replace(/\"/g, '\\\"')}"`;
+    return `"${str.replace(/"/g, '\\"')}"`;
   }
 
   return str;

--- a/src/hoarder-client.test.ts
+++ b/src/hoarder-client.test.ts
@@ -1,12 +1,11 @@
+import { requestUrl } from "obsidian";
 import { HoarderApiClient, HoarderHighlight } from "./hoarder-client";
 
-global.fetch = jest.fn();
-
-const mockFetch = global.fetch as jest.Mock;
+const mockRequestUrl = requestUrl as jest.Mock;
 
 describe("HoarderApiClient", () => {
   beforeEach(() => {
-    mockFetch.mockReset();
+    mockRequestUrl.mockReset();
   });
 
   describe("constructor", () => {
@@ -138,105 +137,103 @@ describe("HoarderApiClient", () => {
     });
 
     it("should set Authorization: Bearer header on requests", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ bookmarks: [], nextCursor: null }),
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { bookmarks: [], nextCursor: null },
       });
 
       await client.getBookmarks();
 
-      const [, options] = mockFetch.mock.calls[0];
+      const [options] = mockRequestUrl.mock.calls[0];
       expect(options.headers["Authorization"]).toBe("Bearer test-key");
     });
 
     it("should set Content-Type: application/json header on requests", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ bookmarks: [] }),
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { bookmarks: [] },
       });
 
       await client.getBookmarks();
 
-      const [, options] = mockFetch.mock.calls[0];
+      const [options] = mockRequestUrl.mock.calls[0];
       expect(options.headers["Content-Type"]).toBe("application/json");
     });
 
     it("should omit undefined query params from URL", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ bookmarks: [] }),
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { bookmarks: [] },
       });
 
       await client.getBookmarks({ limit: 50, cursor: undefined });
 
-      const [url] = mockFetch.mock.calls[0];
-      expect(url).toContain("limit=50");
-      expect(url).not.toContain("cursor");
+      const [options] = mockRequestUrl.mock.calls[0];
+      expect(options.url).toContain("limit=50");
+      expect(options.url).not.toContain("cursor");
     });
 
     it("should include defined query params in URL", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ bookmarks: [] }),
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { bookmarks: [] },
       });
 
       await client.getBookmarks({ limit: 25, cursor: "abc", archived: false });
 
-      const [url] = mockFetch.mock.calls[0];
-      expect(url).toContain("limit=25");
-      expect(url).toContain("cursor=abc");
-      expect(url).toContain("archived=false");
+      const [options] = mockRequestUrl.mock.calls[0];
+      expect(options.url).toContain("limit=25");
+      expect(options.url).toContain("cursor=abc");
+      expect(options.url).toContain("archived=false");
     });
 
     it("should throw on HTTP 401 error", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
+      mockRequestUrl.mockResolvedValueOnce({
         status: 401,
-        text: async () => "Unauthorized",
+        text: "Unauthorized",
       });
 
       await expect(client.getBookmarks()).rejects.toThrow("HTTP 401");
     });
 
     it("should throw on HTTP 500 error", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
+      mockRequestUrl.mockResolvedValueOnce({
         status: 500,
-        text: async () => "Internal Server Error",
+        text: "Internal Server Error",
       });
 
       await expect(client.getBookmarks()).rejects.toThrow("HTTP 500");
     });
 
     it("should send PATCH request with JSON body for updateBookmark", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ id: "b1" }),
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { id: "b1" },
       });
 
       await client.updateBookmark("b1", { note: "my note" });
 
-      const [url, options] = mockFetch.mock.calls[0];
-      expect(url).toContain("/bookmarks/b1");
+      const [options] = mockRequestUrl.mock.calls[0];
+      expect(options.url).toContain("/bookmarks/b1");
       expect(options.method).toBe("PATCH");
       expect(JSON.parse(options.body)).toEqual({ note: "my note" });
     });
 
     it("should use GET with no body for getBookmarks", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ bookmarks: [] }),
+      mockRequestUrl.mockResolvedValueOnce({
+        status: 200,
+        json: { bookmarks: [] },
       });
 
       await client.getBookmarks();
 
-      const [, options] = mockFetch.mock.calls[0];
+      const [options] = mockRequestUrl.mock.calls[0];
       expect(options.method).toBe("GET");
       expect(options.body).toBeUndefined();
     });
 
     it("should rethrow network errors", async () => {
-      mockFetch.mockRejectedValueOnce(new Error("Network failure"));
+      mockRequestUrl.mockRejectedValueOnce(new Error("Network failure"));
 
       await expect(client.getBookmarks()).rejects.toThrow("Network failure");
     });

--- a/src/hoarder-client.ts
+++ b/src/hoarder-client.ts
@@ -69,6 +69,7 @@ export interface PaginatedHighlights {
 }
 
 export interface BookmarkQueryParams {
+  [key: string]: string | number | boolean | undefined;
   limit?: number;
   cursor?: string;
   archived?: boolean;
@@ -79,23 +80,20 @@ export interface BookmarkQueryParams {
 export class HoarderApiClient {
   private baseUrl: string;
   private apiKey: string;
-  private useObsidianRequest: boolean;
 
-  constructor(baseUrl: string, apiKey: string, useObsidianRequest: boolean = false) {
-    this.baseUrl = baseUrl.replace(/\/$/, ""); // Remove trailing slash
+  constructor(baseUrl: string, apiKey: string, _useObsidianRequest: boolean = false) {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
     this.apiKey = apiKey;
-    this.useObsidianRequest = useObsidianRequest;
   }
 
   private async makeRequest<T>(
     endpoint: string,
     method: "GET" | "POST" | "PATCH" | "DELETE" = "GET",
-    body?: any,
-    params?: Record<string, any>
+    body?: Record<string, unknown>,
+    params?: Record<string, unknown>
   ): Promise<T> {
     const url = new URL(`${this.baseUrl}${endpoint}`);
 
-    // Add query parameters
     if (params) {
       Object.entries(params).forEach(([key, value]) => {
         if (value !== undefined && value !== null) {
@@ -110,35 +108,18 @@ export class HoarderApiClient {
     };
 
     try {
-      if (this.useObsidianRequest) {
-        // Use Obsidian's requestUrl to avoid CORS issues
-        const response = await requestUrl({
-          url: url.toString(),
-          method,
-          headers,
-          body: body ? JSON.stringify(body) : undefined,
-        });
+      const response = await requestUrl({
+        url: url.toString(),
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+      });
 
-        if (response.status >= 400) {
-          throw new Error(`HTTP ${response.status}: ${response.text || "Unknown error"}`);
-        }
-
-        return response.json;
-      } else {
-        // Use standard fetch
-        const response = await fetch(url.toString(), {
-          method,
-          headers,
-          body: body ? JSON.stringify(body) : undefined,
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(`HTTP ${response.status}: ${errorText || "Unknown error"}`);
-        }
-
-        return await response.json();
+      if (response.status >= 400) {
+        throw new Error(`HTTP ${response.status}: ${response.text || "Unknown error"}`);
       }
+
+      return response.json as T;
     } catch (error) {
       console.error("API request failed:", url.toString(), error);
       throw error;
@@ -151,7 +132,7 @@ export class HoarderApiClient {
 
   async updateBookmark(
     bookmarkId: string,
-    data: { note?: string; [key: string]: any }
+    data: { note?: string; [key: string]: unknown }
   ): Promise<HoarderBookmark> {
     return this.makeRequest<HoarderBookmark>(`/bookmarks/${bookmarkId}`, "PATCH", data);
   }
@@ -193,37 +174,16 @@ export class HoarderApiClient {
     };
 
     try {
-      if (this.useObsidianRequest) {
-        const response = await requestUrl({
-          url,
-          method: "GET",
-          headers,
-        });
+      const response = await requestUrl({ url, method: "GET", headers });
 
-        if (response.status >= 400) {
-          throw new Error(`HTTP ${response.status}: ${response.text || "Unknown error"}`);
-        }
-
-        return {
-          buffer: response.arrayBuffer,
-          contentType: response.headers["content-type"] || null,
-        };
-      } else {
-        const response = await fetch(url, {
-          method: "GET",
-          headers,
-        });
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(`HTTP ${response.status}: ${errorText || "Unknown error"}`);
-        }
-
-        return {
-          buffer: await response.arrayBuffer(),
-          contentType: response.headers.get("content-type"),
-        };
+      if (response.status >= 400) {
+        throw new Error(`HTTP ${response.status}: ${response.text || "Unknown error"}`);
       }
+
+      return {
+        buffer: response.arrayBuffer,
+        contentType: response.headers["content-type"] || null,
+      };
     } catch (error) {
       console.error("Asset download failed:", url, error);
       throw error;

--- a/src/hoarder-client.ts
+++ b/src/hoarder-client.ts
@@ -32,6 +32,7 @@ export interface HoarderBookmarkContent {
   favicon?: string | null;
   htmlContent?: string | null;
   crawledAt?: string | null;
+  author?: string | null;
   text?: string;
   sourceUrl?: string | null;
   assetType?: "image" | "pdf";

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,23 +57,19 @@ export default class HoarderPlugin extends Plugin {
 
     // Register file modification event
     this.registerEvent(
-      this.app.vault.on("modify", async (file) => {
-        // Check if it's a markdown file in our sync folder
+      this.app.vault.on("modify", (file) => {
         if (
           this.settings.syncNotesToHoarder &&
           file.path.startsWith(this.settings.syncFolder) &&
           file.path.endsWith(".md") &&
           file instanceof TFile
         ) {
-          // Clear any existing timeout
           if (this.modificationTimeout) {
             window.clearTimeout(this.modificationTimeout);
           }
-
-          // Set a new timeout
-          this.modificationTimeout = window.setTimeout(async () => {
-            await this.handleFileModification(file);
-          }, 2000); // Wait 2 seconds after last modification
+          this.modificationTimeout = window.setTimeout(() => {
+            void this.handleFileModification(file);
+          }, 2000);
         }
       })
     );
@@ -112,12 +108,10 @@ export default class HoarderPlugin extends Plugin {
     // Convert minutes to milliseconds
     const interval = this.settings.syncIntervalMinutes * 60 * 1000;
 
-    // Perform initial sync
-    this.syncBookmarks();
+    void this.syncBookmarks();
 
-    // Set up periodic sync
     this.syncIntervalId = window.setInterval(() => {
-      this.syncBookmarks();
+      void this.syncBookmarks();
     }, interval);
   }
 
@@ -267,11 +261,11 @@ export default class HoarderPlugin extends Plugin {
 
       try {
         switch (instruction.action) {
-          case "delete":
-            await this.app.vault.delete(file);
+          case "delete": {
+            await this.app.fileManager.trashFile(file);
             break;
-
-          case "archive":
+          }
+          case "archive": {
             const archiveFolder =
               instruction.reason === "deleted"
                 ? this.settings.archiveFolder
@@ -281,14 +275,15 @@ export default class HoarderPlugin extends Plugin {
             }
             await this.moveToArchiveFolder(file, archiveFolder);
             break;
-
-          case "tag":
+          }
+          case "tag": {
             const tag =
               instruction.reason === "deleted"
                 ? this.settings.deletionTag
                 : this.settings.archivedBookmarkTag;
             await this.addDeletionTag(file, tag);
             break;
+          }
         }
       } catch (error) {
         console.error(`Error handling bookmark ${instruction.bookmarkId}:`, error);
@@ -353,26 +348,19 @@ export default class HoarderPlugin extends Plugin {
 
   async syncBookmarks(): Promise<{ success: boolean; message: string }> {
     if (this.isSyncing) {
-      console.error("[Hoarder] Sync already in progress");
       return { success: false, message: "Sync already in progress" };
     }
 
     if (!this.settings.apiKey) {
-      console.log("[Hoarder] API key not configured");
       return { success: false, message: "Hoarder API key not configured" };
     }
 
-    console.log("[Hoarder] Starting sync...");
-    console.log(
-      `[Hoarder] Settings: syncNotesToHoarder=${this.settings.syncNotesToHoarder}, updateExistingFiles=${this.settings.updateExistingFiles}`
-    );
     this.setSyncing(true);
     let totalBookmarks = 0;
     this.skippedFiles = 0;
     let updatedInHoarder = 0;
     let excludedByTags = 0;
     let includedByTags = 0;
-    let totalBookmarksProcessed = 0;
     let skippedNoHighlights = 0;
 
     try {
@@ -390,7 +378,6 @@ export default class HoarderPlugin extends Plugin {
       const allBookmarks = await this.fetchAllBookmarks(true); // All bookmarks including archived
 
       const activeBookmarkIds = new Set(activeBookmarks.map((b) => b.id));
-      const allBookmarkIds = new Set(allBookmarks.map((b) => b.id));
       const archivedBookmarkIds = new Set(
         allBookmarks.filter((b) => b.archived && !activeBookmarkIds.has(b.id)).map((b) => b.id)
       );
@@ -425,7 +412,6 @@ export default class HoarderPlugin extends Plugin {
         const result = await this.fetchBookmarks(cursor);
         const bookmarks = result.bookmarks || [];
         cursor = result.nextCursor || undefined;
-        totalBookmarksProcessed += bookmarks.length;
 
         // Process each bookmark
         for (const bookmark of bookmarks) {
@@ -472,21 +458,6 @@ export default class HoarderPlugin extends Plugin {
             const file = this.app.vault.getAbstractFileByPath(fileName);
             if (file instanceof TFile) {
               const metadata = this.app.metadataCache.getFileCache(file)?.frontmatter;
-              const storedModifiedTime = metadata?.modified
-                ? new Date(metadata.modified).getTime()
-                : 0;
-              const bookmarkModifiedTime = bookmark.modifiedAt
-                ? new Date(bookmark.modifiedAt).getTime()
-                : new Date(bookmark.createdAt).getTime();
-
-              // Check if there are new highlights since last file update
-              let hasNewHighlights = false;
-              if (this.settings.syncHighlights && highlights.length > 0) {
-                const newestHighlightTime = Math.max(
-                  ...highlights.map((h) => new Date(h.createdAt).getTime())
-                );
-                hasNewHighlights = !storedModifiedTime || newestHighlightTime > storedModifiedTime;
-              }
 
               // Check if we should update existing files based on user setting
               if (!this.settings.updateExistingFiles) {
@@ -502,11 +473,7 @@ export default class HoarderPlugin extends Plugin {
 
                 // Initialize original_note if it's missing
                 if (originalNotes === null && currentNotes !== null) {
-                  console.debug(`[Hoarder] original_note missing for ${fileName}`);
-
-                  // If current notes differ from remote, sync them to Hoarder
-                  if (currentNotes !== remoteNotes) {
-                    console.log(`[Hoarder] Local notes differ from remote, syncing to Hoarder`);
+                          if (currentNotes !== remoteNotes) {
                     const updated = await this.updateBookmarkInHoarder(bookmark.id, currentNotes);
                     if (updated) {
                       updatedInHoarder++;
@@ -522,8 +489,6 @@ export default class HoarderPlugin extends Plugin {
                   currentNotes !== originalNotes &&
                   currentNotes !== remoteNotes
                 ) {
-                  // Local notes have changed from original, update in Hoarder
-                  console.log(`[Hoarder] Local notes changed for ${fileName}, syncing to Hoarder`);
                   const updated = await this.updateBookmarkInHoarder(bookmark.id, currentNotes);
                   if (updated) {
                     updatedInHoarder++;
@@ -625,124 +590,79 @@ export default class HoarderPlugin extends Plugin {
 
   private async handleFileModification(file: TFile) {
     try {
-      console.debug(`[Hoarder] File modified: ${file.path}`);
-
-      // Extract current and original notes
       const { currentNotes, originalNotes } = await this.extractNotesFromFile(file.path);
 
-      // Convert null to empty string for comparison
       const currentNotesStr = currentNotes || "";
       const originalNotesStr = originalNotes || "";
 
-      console.log(
-        `[Hoarder] Current notes length: ${currentNotesStr.length}, Original notes length: ${originalNotesStr.length}`
-      );
-
-      // Skip if we just synced these exact notes
       if (currentNotesStr === this.lastSyncedNotes) {
-        console.log("[Hoarder] Skipping - notes match last synced version");
         return;
       }
 
-      // Get bookmark ID from frontmatter using MetadataCache
       const metadata = this.app.metadataCache.getFileCache(file)?.frontmatter;
       const bookmarkId = metadata?.bookmark_id;
       if (!bookmarkId) {
-        console.log("[Hoarder] No bookmark_id found in frontmatter");
         return;
       }
 
-      console.log(`[Hoarder] Bookmark ID: ${bookmarkId}`);
-
-      // If original_note is null/undefined, initialize it to current value from frontmatter
-      // This handles files that were created before this fix or when updateExistingFiles was disabled
       if (originalNotes === null) {
         const frontmatterNote = metadata?.note || "";
-        console.log(`[Hoarder] original_note is null for ${file.path}`);
 
-        // Check if current notes differ from what's in frontmatter
         if (currentNotesStr !== frontmatterNote) {
-          console.log("[Hoarder] Notes have changed from frontmatter note");
           const success = await this.updateBookmarkInHoarder(bookmarkId, currentNotesStr);
           if (success) {
             this.lastSyncedNotes = currentNotesStr;
 
-            // Initialize original_note after successful sync
-            setTimeout(async () => {
-              try {
-                const { currentNotes: latestNotes, originalNotes: currentOriginalNotes } =
-                  await this.extractNotesFromFile(file.path);
-                // Only update if notes haven't changed AND original_note still needs initialization
-                if (latestNotes === currentNotesStr && currentOriginalNotes !== currentNotesStr) {
-                  await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
-                    frontmatter["original_note"] = currentNotesStr;
-                  });
-                  console.debug("[Hoarder] Initialized and updated original_note in frontmatter");
-                } else if (currentOriginalNotes === currentNotesStr) {
-                  console.debug(
-                    "[Hoarder] original_note already initialized, skipping frontmatter update"
-                  );
+            window.setTimeout(() => {
+              void (async () => {
+                try {
+                  const { currentNotes: latestNotes, originalNotes: currentOriginalNotes } =
+                    await this.extractNotesFromFile(file.path);
+                  if (latestNotes === currentNotesStr && currentOriginalNotes !== currentNotesStr) {
+                    await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+                      frontmatter["original_note"] = currentNotesStr;
+                    });
+                  }
+                } catch (error) {
+                  console.error("[Hoarder] Error updating frontmatter:", error);
                 }
-              } catch (error) {
-                console.error("[Hoarder] Error updating frontmatter:", error);
-              }
+              })();
             }, 5000);
 
             new Notice("Notes synced to Hoarder");
           } else {
             console.error("[Hoarder] Failed to update bookmark in Hoarder");
           }
-        } else {
-          // Notes match frontmatter note, skip initialization to preserve mtime
-          // The field will be initialized on the next actual change
-          console.debug(
-            "[Hoarder] Notes match frontmatter, skipping original_note initialization to preserve mtime"
-          );
         }
         return;
       }
 
-      // Only update if notes have changed
       if (currentNotesStr !== originalNotesStr) {
-        console.log("[Hoarder] Notes have changed, syncing to Hoarder");
         const updated = await this.updateBookmarkInHoarder(bookmarkId, currentNotesStr);
         if (updated) {
-          // Store these notes as the last synced version
           this.lastSyncedNotes = currentNotesStr;
-          console.log("[Hoarder] Successfully synced notes to Hoarder");
 
-          // Schedule frontmatter update for later
-          setTimeout(async () => {
-            try {
-              // Re-read the file to get the latest content
-              const { currentNotes: latestNotes, originalNotes: currentOriginalNotes } =
-                await this.extractNotesFromFile(file.path);
-
-              // Only update frontmatter if notes haven't changed since sync AND original_note needs updating
-              if (latestNotes === currentNotesStr && currentOriginalNotes !== currentNotesStr) {
-                await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
-                  frontmatter["original_note"] = currentNotesStr;
-                });
-                console.debug("[Hoarder] Updated original_note in frontmatter");
-              } else if (latestNotes !== currentNotesStr) {
-                console.debug("[Hoarder] Notes changed again, skipping frontmatter update");
-              } else {
-                console.debug(
-                  "[Hoarder] original_note already up to date, skipping frontmatter update"
-                );
+          window.setTimeout(() => {
+            void (async () => {
+              try {
+                const { currentNotes: latestNotes, originalNotes: currentOriginalNotes } =
+                  await this.extractNotesFromFile(file.path);
+                if (latestNotes === currentNotesStr && currentOriginalNotes !== currentNotesStr) {
+                  await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+                    frontmatter["original_note"] = currentNotesStr;
+                  });
+                }
+              } catch (error) {
+                console.error("[Hoarder] Error updating frontmatter:", error);
               }
-            } catch (error) {
-              console.error("[Hoarder] Error updating frontmatter:", error);
-            }
-          }, 5000); // Wait 5 seconds before updating frontmatter
+            })();
+          }, 5000);
 
           new Notice("Notes synced to Hoarder");
         } else {
           console.error("[Hoarder] Failed to update bookmark in Hoarder");
           new Notice("Failed to sync notes to Hoarder");
         }
-      } else {
-        console.log("[Hoarder] Notes unchanged, no sync needed");
       }
     } catch (error) {
       console.error("[Hoarder] Error handling file modification:", error);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import { EditorView } from "@codemirror/view";
-import { AbstractInputSuggest, App, Notice, PluginSettingTab, Setting, TFolder } from "obsidian";
+import { AbstractInputSuggest, App, ButtonComponent, Notice, PluginSettingTab, Setting, TFolder } from "obsidian";
 
 import HoarderPlugin from "./main";
 import { createTemplateEditor, setEditorValue } from "./template-editor";
@@ -109,7 +109,7 @@ class FolderSuggest extends AbstractInputSuggest<TFolder> {
 
 export class HoarderSettingTab extends PluginSettingTab {
   plugin: HoarderPlugin;
-  syncButton: any;
+  syncButton: ButtonComponent | null = null;
   private templateEditor: EditorView | null = null;
 
   constructor(app: App, plugin: HoarderPlugin) {
@@ -140,8 +140,8 @@ export class HoarderSettingTab extends PluginSettingTab {
     // =================
     // API Configuration
     // =================
-    containerEl.createEl("h3", { text: "API Configuration" });
-    containerEl.createEl("div", {
+    new Setting(containerEl).setName("API Configuration").setHeading();
+    containerEl.createDiv({
       text: "Connection settings for your Karakeep instance",
       cls: "hoarder-section-description",
     });
@@ -189,8 +189,8 @@ export class HoarderSettingTab extends PluginSettingTab {
     // =================
     // File Organization
     // =================
-    containerEl.createEl("h3", { text: "File Organization" });
-    containerEl.createEl("div", {
+    new Setting(containerEl).setName("File Organization").setHeading();
+    containerEl.createDiv({
       text: "Configure where your bookmarks and assets are stored",
       cls: "hoarder-section-description",
     });
@@ -232,8 +232,8 @@ export class HoarderSettingTab extends PluginSettingTab {
     // =================
     // Sync Behavior
     // =================
-    containerEl.createEl("h3", { text: "Sync Behavior" });
-    containerEl.createEl("div", {
+    new Setting(containerEl).setName("Sync Behavior").setHeading();
+    containerEl.createDiv({
       text: "Control how synchronization works",
       cls: "hoarder-section-description",
     });
@@ -346,8 +346,8 @@ export class HoarderSettingTab extends PluginSettingTab {
     // =================
     // Note Template
     // =================
-    containerEl.createEl("h3", { text: "Note Template" });
-    containerEl.createEl("div", {
+    new Setting(containerEl).setName("Note Template").setHeading();
+    containerEl.createDiv({
       text: "Customize the format of synced bookmark notes using Eta template syntax",
       cls: "hoarder-section-description",
     });
@@ -368,45 +368,61 @@ export class HoarderSettingTab extends PluginSettingTab {
 
     if (this.plugin.settings.useCustomTemplate) {
       if (this.plugin.settings.syncNotesToHoarder) {
-        containerEl.createEl("div", {
+        containerEl.createDiv({
           text: "Warning: Your template must include a ## Notes section and original_note frontmatter field for bi-directional sync to work.",
-          cls: "hoarder-section-description",
-        }).style.color = "var(--text-error)";
+          cls: "hoarder-section-description hoarder-text-error",
+        });
       }
 
-      containerEl.createEl("div", {
+      containerEl.createDiv({
         text: "Eta template for bookmark notes. Use <%= it.variable %> for output, <% if (condition) { %> for logic.",
         cls: "hoarder-section-description",
       });
 
       const details = containerEl.createEl("details", { cls: "hoarder-template-reference" });
       details.createEl("summary", { text: "Available template variables" });
-      const refContent = details.createEl("div", { cls: "hoarder-template-ref-content" });
-      refContent.innerHTML = `
-<strong>Bookmark fields</strong>
-<code>it.bookmark_id</code> <code>it.title</code> <code>it.url</code> <code>it.description</code>
-<code>it.note</code> (raw text) <code>it.noteBlock</code> (editable, wrapped in comment markers)
-<code>it.summary</code> <code>it.created_at</code> <code>it.modified_at</code>
-<code>it.content_type</code> ("link", "text", "asset") <code>it.content_html</code>
-<code>it.author</code> <code>it.archived</code> <code>it.favourited</code>
-<code>it.tags</code> (string array) <code>it.hoarder_url</code> <code>it.visit_link</code>
+      const refContent = details.createDiv({ cls: "hoarder-template-ref-content" });
 
-<strong>Pre-escaped for YAML frontmatter</strong>
-<code>it.yaml.url</code> <code>it.yaml.title</code> <code>it.yaml.note</code> <code>it.yaml.summary</code>
+      const addVarLine = (parent: HTMLElement, codes: string[], suffix?: string) => {
+        const div = parent.createDiv();
+        for (const c of codes) {
+          div.createEl("code", { text: c });
+          div.appendText(" ");
+        }
+        if (suffix) div.appendText(suffix);
+      };
 
-<strong>Assets</strong>
-<code>it.assets.content</code> (rendered embeds)
-<code>it.assets.banner</code> <code>it.assets.screenshot</code> <code>it.assets.image</code>
-<code>it.assets.full_page_archive</code> <code>it.assets.pdf_archive</code> <code>it.assets.video</code>
-<code>it.assets.additional</code> (string array)
+      refContent.createEl("strong", { text: "Bookmark fields" });
+      addVarLine(refContent, ["it.bookmark_id", "it.title", "it.url", "it.description"]);
+      addVarLine(refContent, ["it.note"], "(raw text)");
+      addVarLine(refContent, ["it.noteBlock"], "(editable, wrapped in comment markers)");
+      addVarLine(refContent, ["it.summary", "it.created_at", "it.modified_at"]);
+      addVarLine(refContent, ["it.content_type"], '("link", "text", "asset")');
+      addVarLine(refContent, ["it.content_html", "it.author", "it.archived", "it.favourited"]);
+      addVarLine(refContent, ["it.tags"], "(string array)");
+      addVarLine(refContent, ["it.hoarder_url", "it.visit_link"]);
 
-<strong>Highlights</strong> (array, each has:)
-<code>.id</code> <code>.color</code> <code>.text</code> <code>.note</code> <code>.date</code> <code>.created_at</code>
-<code>it.sync_highlights</code> (boolean)
+      refContent.createEl("br");
+      refContent.createEl("strong", { text: "Pre-escaped for YAML frontmatter" });
+      addVarLine(refContent, ["it.yaml.url", "it.yaml.title", "it.yaml.note", "it.yaml.summary"]);
 
-<strong>Helper functions</strong>
-<code>it.escapeYaml(str)</code> <code>it.escapeMarkdownPath(str)</code> <code>it.formatDate(iso)</code>
-      `.trim();
+      refContent.createEl("br");
+      refContent.createEl("strong", { text: "Assets" });
+      addVarLine(refContent, ["it.assets.content"], "(rendered embeds)");
+      addVarLine(refContent, ["it.assets.banner", "it.assets.screenshot", "it.assets.image"]);
+      addVarLine(refContent, ["it.assets.full_page_archive", "it.assets.pdf_archive", "it.assets.video"]);
+      addVarLine(refContent, ["it.assets.additional"], "(string array)");
+
+      refContent.createEl("br");
+      const highlightsLine = refContent.createDiv();
+      highlightsLine.createEl("strong", { text: "Highlights" });
+      highlightsLine.appendText(" (array, each has:)");
+      addVarLine(refContent, [".id", ".color", ".text", ".note", ".date", ".created_at"]);
+      addVarLine(refContent, ["it.sync_highlights"], "(boolean)");
+
+      refContent.createEl("br");
+      refContent.createEl("strong", { text: "Helper functions" });
+      addVarLine(refContent, ["it.escapeYaml(str)", "it.escapeMarkdownPath(str)", "it.formatDate(iso)"]);
 
       const editorContainer = containerEl.createDiv({ cls: "hoarder-template-editor" });
 
@@ -465,8 +481,8 @@ export class HoarderSettingTab extends PluginSettingTab {
     // =================
     // Sync Filtering
     // =================
-    containerEl.createEl("h3", { text: "Sync Filtering" });
-    containerEl.createEl("div", {
+    new Setting(containerEl).setName("Sync Filtering").setHeading();
+    containerEl.createDiv({
       text: "Control which bookmarks are synchronized",
       cls: "hoarder-section-description",
     });
@@ -544,13 +560,13 @@ export class HoarderSettingTab extends PluginSettingTab {
     // =================
     // Deletion Handling
     // =================
-    containerEl.createEl("h3", { text: "Deletion Handling" });
-    containerEl.createEl("div", {
+    new Setting(containerEl).setName("Deletion Handling").setHeading();
+    containerEl.createDiv({
       text: "Configure what happens when bookmarks are deleted in Karakeep",
       cls: "hoarder-section-description",
     });
 
-    const syncDeletionsToggle = new Setting(containerEl)
+    new Setting(containerEl)
       .setName("Sync deletions")
       .setDesc("Automatically handle bookmarks that are deleted in Karakeep")
       .addToggle((toggle) =>
@@ -562,7 +578,7 @@ export class HoarderSettingTab extends PluginSettingTab {
       );
 
     if (this.plugin.settings.syncDeletions) {
-      const deletionActionSetting = new Setting(containerEl)
+      new Setting(containerEl)
         .setName("Deletion action")
         .setDesc("What to do with local files when bookmarks are deleted in Karakeep")
         .addDropdown((dropdown) =>
@@ -617,13 +633,13 @@ export class HoarderSettingTab extends PluginSettingTab {
     // =================
     // Archive Handling
     // =================
-    containerEl.createEl("h3", { text: "Archive Handling" });
-    containerEl.createEl("div", {
+    new Setting(containerEl).setName("Archive Handling").setHeading();
+    containerEl.createDiv({
       text: "Configure what happens when bookmarks are archived in Karakeep",
       cls: "hoarder-section-description",
     });
 
-    const handleArchivedToggle = new Setting(containerEl)
+    new Setting(containerEl)
       .setName("Handle archived bookmarks")
       .setDesc("Separately handle bookmarks that are archived (not deleted) in Karakeep")
       .addToggle((toggle) =>
@@ -635,7 +651,7 @@ export class HoarderSettingTab extends PluginSettingTab {
       );
 
     if (this.plugin.settings.handleArchivedBookmarks) {
-      const archivedActionSetting = new Setting(containerEl)
+      new Setting(containerEl)
         .setName("Archived bookmark action")
         .setDesc("What to do with local files when bookmarks are archived in Karakeep")
         .addDropdown((dropdown) =>
@@ -691,8 +707,8 @@ export class HoarderSettingTab extends PluginSettingTab {
     // =================
     // Manual Actions & Status
     // =================
-    containerEl.createEl("h3", { text: "Manual Actions & Status" });
-    containerEl.createEl("div", {
+    new Setting(containerEl).setName("Manual Actions & Status").setHeading();
+    containerEl.createDiv({
       text: "Manual sync controls and synchronization status",
       cls: "hoarder-section-description",
     });
@@ -718,7 +734,7 @@ export class HoarderSettingTab extends PluginSettingTab {
 
     // Add Last Sync Time
     if (this.plugin.settings.lastSyncTimestamp > 0) {
-      containerEl.createEl("div", {
+      containerEl.createDiv({
         text: `Last synced: ${new Date(this.plugin.settings.lastSyncTimestamp).toLocaleString()}`,
         cls: "hoarder-section-description",
       });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -388,7 +388,7 @@ export class HoarderSettingTab extends PluginSettingTab {
 <code>it.note</code> (raw text) <code>it.noteBlock</code> (editable, wrapped in comment markers)
 <code>it.summary</code> <code>it.created_at</code> <code>it.modified_at</code>
 <code>it.content_type</code> ("link", "text", "asset") <code>it.content_html</code>
-<code>it.archived</code> <code>it.favourited</code>
+<code>it.author</code> <code>it.archived</code> <code>it.favourited</code>
 <code>it.tags</code> (string array) <code>it.hoarder_url</code> <code>it.visit_link</code>
 
 <strong>Pre-escaped for YAML frontmatter</strong>

--- a/src/tag-utils.ts
+++ b/src/tag-utils.ts
@@ -37,7 +37,7 @@ export function sanitizeTag(tag: string): string | null {
 
   // If tag starts with only numbers followed by invalid characters (edge case),
   // prepend with "tag-" to ensure at least one non-numerical character
-  if (/^[\d\/\-_]+$/.test(sanitized)) {
+  if (/^[\d/\-_]+$/.test(sanitized)) {
     sanitized = "tag-" + sanitized;
   }
 

--- a/src/template-renderer.ts
+++ b/src/template-renderer.ts
@@ -20,6 +20,7 @@ export interface TemplateContext {
   favourited: boolean;
   content_type: string;
   content_html: string | undefined | null;
+  author: string | undefined | null;
   tags: string[];
   yaml: {
     url: string;
@@ -168,6 +169,7 @@ export function buildTemplateContext(
     favourited: bookmark.favourited,
     content_type: bookmark.content.type,
     content_html: bookmark.content.htmlContent ? sanitizeHtml(bookmark.content.htmlContent) : null,
+    author: bookmark.content.author ?? null,
     tags,
     yaml: {
       url: escapeYaml(url),
@@ -231,6 +233,7 @@ const SAMPLE_CONTEXT: TemplateContext = {
   favourited: false,
   content_type: "link",
   content_html: null,
+  author: "Sample Author",
   tags: ["sample-tag"],
   yaml: {
     url: "https://example.com",

--- a/src/template-renderer.ts
+++ b/src/template-renderer.ts
@@ -266,16 +266,16 @@ export function validateTemplate(
   // 1. Check syntax (compilation)
   try {
     eta.compile(templateString);
-  } catch (error: any) {
-    return { valid: false, error: `Syntax error: ${error.message || String(error)}` };
+  } catch (error: unknown) {
+    return { valid: false, error: `Syntax error: ${error instanceof Error ? error.message : String(error)}` };
   }
 
   // 2. Test render with sample data
   let rendered: string;
   try {
     rendered = renderTemplate(templateString, SAMPLE_CONTEXT);
-  } catch (error: any) {
-    return { valid: false, error: `Render error: ${error.message || String(error)}` };
+  } catch (error: unknown) {
+    return { valid: false, error: `Render error: ${error instanceof Error ? error.message : String(error)}` };
   }
 
   // 3. Check output structure

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,4 @@
 /* Settings panel normalization — override theme card styles */
-.hoarder-settings h3 {
-  margin-left: 0 !important;
-  padding-left: 0 !important;
-}
-
 .hoarder-settings .setting-item {
   border: none !important;
   border-top: 1px solid var(--background-modifier-border) !important;
@@ -60,6 +55,10 @@
   margin-bottom: var(--size-4-4);
   color: var(--text-muted);
   font-size: var(--font-ui-smaller);
+}
+
+.hoarder-text-error {
+  color: var(--text-error);
 }
 
 .hoarder-template-editor {


### PR DESCRIPTION
## Summary

- Replaces `fetch()` with Obsidian's `requestUrl()` everywhere, fixes `Vault.delete()` → `fileManager.trashFile()`, and adds `void`/`window.setTimeout` for proper promise and popout-window handling
- Replaces raw `createEl("h3")` with `new Setting().setHeading()`, `createEl("div")` with `createDiv()`, and `innerHTML` with DOM API methods in the settings panel
- Removes 8 unused variables, fixes `any` types, unnecessary regex escapes, and lexical declarations in switch case blocks
- Adds artifact attestations and auto-generated release notes to the release workflow
- Adds `CONTRIBUTING.md`, trailing punctuation to the manifest description, and moves `builtin-modules` to Node's built-in `module.builtinModules`

## Test plan

- [x] `npm run build` passes with no errors
- [x] All 456 tests pass (`npm test`)
- [x] `hoarder-client` tests updated to mock `requestUrl` instead of `fetch`
- [ ] Verify release workflow produces attested assets on next tag push