### PR TITLE
Fix Obsidian-safe bookmark filenames

### DIFF
--- a/src/filename-utils.test.ts
+++ b/src/filename-utils.test.ts
@@ -52,8 +52,14 @@ describe("sanitizeFileName", () => {
       expect(sanitizeFileName("My|Title", testDate)).toBe("2024-01-15-My-Title");
     });
 
+    it("should replace Obsidian wikilink-reserved characters with dashes", () => {
+      expect(sanitizeFileName("Ultimate Primer #1: The [One] Word^Block", testDate)).toBe(
+        "2024-01-15-Ultimate-Primer-1-The-One-Word-Block"
+      );
+    });
+
     it("should handle multiple invalid characters", () => {
-      expect(sanitizeFileName('My\\/:*?"<>|Title', testDate)).toBe("2024-01-15-My-Title");
+      expect(sanitizeFileName('My\\/:*?"<>|#^[]Title', testDate)).toBe("2024-01-15-My-Title");
     });
   });
 
@@ -184,7 +190,7 @@ describe("sanitizeFileName", () => {
 
     it("should handle titles with brackets", () => {
       expect(sanitizeFileName("My [Important] Title", testDate)).toBe(
-        "2024-01-15-My-[Important]-Title"
+        "2024-01-15-My-Important-Title"
       );
     });
 

--- a/src/filename-utils.ts
+++ b/src/filename-utils.ts
@@ -13,9 +13,9 @@ export function sanitizeFileName(title: string, createdAt: string | Date): strin
   const date = typeof createdAt === "string" ? new Date(createdAt) : createdAt;
   const dateStr = date.toISOString().split("T")[0]; // This is 10 characters
 
-  // Sanitize the title
+  // Sanitize the title for filesystem and Obsidian wikilink compatibility.
   let sanitizedTitle = title
-    .replace(/[\\/:*?"<>|]/g, "-") // Replace invalid filesystem characters with dash
+    .replace(/[\\/:*?"<>|#^\[\]]/g, "-") // Replace unsafe filename/link characters with dash
     .replace(/\s+/g, "-") // Replace spaces with dash
     .replace(/-+/g, "-") // Replace multiple dashes with single dash
     .replace(/^-|-$/g, ""); // Remove dashes from start and end


### PR DESCRIPTION
## Summary
- Replace Obsidian wikilink-reserved filename characters with dashes during bookmark filename sanitization
- Covers #, ^, [, and ] in filename sanitization tests
- Updates bracket filename expectation to avoid generated wikilink syntax conflicts

Fixes #51

## Verification
- npm test
- npm run build