### PR TITLE
Fix empty local note overwriting remote note

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
 } from "./hoarder-client";
 import { contentHasChanged, extractNotesSection } from "./markdown-utils";
 import { SyncStats, buildSyncMessage } from "./message-utils";
+import { shouldPushLocalNotesToRemote } from "./note-sync-utils";
 import { DEFAULT_SETTINGS, HoarderSettingTab, HoarderSettings } from "./settings";
 import {
   DEFAULT_TEMPLATE,
@@ -471,23 +472,13 @@ export default class HoarderPlugin extends Plugin {
                 const { currentNotes, originalNotes } = await this.extractNotesFromFile(fileName);
                 const remoteNotes = bookmark.note || "";
 
-                // Initialize original_note if it's missing
-                if (originalNotes === null && currentNotes !== null) {
-                          if (currentNotes !== remoteNotes) {
-                    const updated = await this.updateBookmarkInHoarder(bookmark.id, currentNotes);
-                    if (updated) {
-                      updatedInHoarder++;
-                      bookmark.note = currentNotes; // Update the bookmark object with local notes
-                      this.lastSyncedNotes = currentNotes; // Track this to avoid re-syncing
-                    }
-                  }
-                  // original_note will be written as part of formatBookmarkAsMarkdown below,
-                  // so no need for a separate processFrontMatter call that would touch mtime
-                } else if (
+                if (
                   currentNotes !== null &&
-                  originalNotes !== null &&
-                  currentNotes !== originalNotes &&
-                  currentNotes !== remoteNotes
+                  shouldPushLocalNotesToRemote({
+                    currentNotes,
+                    originalNotes,
+                    remoteNotes,
+                  })
                 ) {
                   const updated = await this.updateBookmarkInHoarder(bookmark.id, currentNotes);
                   if (updated) {

--- a/src/note-sync-utils.test.ts
+++ b/src/note-sync-utils.test.ts
@@ -1,0 +1,73 @@
+import { shouldPushLocalNotesToRemote } from "./note-sync-utils";
+
+describe("shouldPushLocalNotesToRemote", () => {
+  it("should not push when no local notes can be extracted", () => {
+    expect(
+      shouldPushLocalNotesToRemote({
+        currentNotes: null,
+        originalNotes: null,
+        remoteNotes: "remote note",
+      })
+    ).toBe(false);
+  });
+
+  it("should not push empty local notes without sync history over remote notes", () => {
+    expect(
+      shouldPushLocalNotesToRemote({
+        currentNotes: "",
+        originalNotes: null,
+        remoteNotes: "remote note",
+      })
+    ).toBe(false);
+  });
+
+  it("should push non-empty local notes without sync history when they differ from remote notes", () => {
+    expect(
+      shouldPushLocalNotesToRemote({
+        currentNotes: "local note",
+        originalNotes: null,
+        remoteNotes: "remote note",
+      })
+    ).toBe(true);
+  });
+
+  it("should not push non-empty local notes without sync history when they match remote notes", () => {
+    expect(
+      shouldPushLocalNotesToRemote({
+        currentNotes: "same note",
+        originalNotes: null,
+        remoteNotes: "same note",
+      })
+    ).toBe(false);
+  });
+
+  it("should push local changes when they differ from original and remote notes", () => {
+    expect(
+      shouldPushLocalNotesToRemote({
+        currentNotes: "updated note",
+        originalNotes: "original note",
+        remoteNotes: "remote note",
+      })
+    ).toBe(true);
+  });
+
+  it("should not push when local notes match original notes", () => {
+    expect(
+      shouldPushLocalNotesToRemote({
+        currentNotes: "original note",
+        originalNotes: "original note",
+        remoteNotes: "remote note",
+      })
+    ).toBe(false);
+  });
+
+  it("should not push when local notes already match remote notes", () => {
+    expect(
+      shouldPushLocalNotesToRemote({
+        currentNotes: "remote note",
+        originalNotes: "original note",
+        remoteNotes: "remote note",
+      })
+    ).toBe(false);
+  });
+});

--- a/src/note-sync-utils.ts
+++ b/src/note-sync-utils.ts
@@ -1,0 +1,21 @@
+export interface NoteSyncState {
+  currentNotes: string | null;
+  originalNotes: string | null;
+  remoteNotes: string;
+}
+
+export function shouldPushLocalNotesToRemote({
+  currentNotes,
+  originalNotes,
+  remoteNotes,
+}: NoteSyncState): boolean {
+  if (currentNotes === null) {
+    return false;
+  }
+
+  if (originalNotes === null) {
+    return currentNotes !== "" && currentNotes !== remoteNotes;
+  }
+
+  return currentNotes !== originalNotes && currentNotes !== remoteNotes;
+}


### PR DESCRIPTION
## Summary
- Prevent empty local notes from overwriting non-empty Karakeep notes when no local original_note history exists
- Preserve intentional note deletion when original_note history exists locally
- Extract note sync push decision into a focused helper with regression coverage

Fixes #52

## Verification
- npm test -- src/note-sync-utils.test.ts src/markdown-utils.test.ts
- npm test
- npm run build