### PR TITLE
Add optional list membership to synced bookmark notes

### DIFF
--- a/src/formatting-utils.test.ts
+++ b/src/formatting-utils.test.ts
@@ -1,4 +1,4 @@
-import { escapeMarkdownPath, escapeYaml, sanitizeHtml } from "./formatting-utils";
+import { escapeMarkdownPath, escapeYaml, escapeYamlListItem, sanitizeHtml } from "./formatting-utils";
 
 describe("escapeYaml", () => {
   describe("null and empty handling", () => {
@@ -194,6 +194,34 @@ describe("escapeYaml", () => {
       const desc = "Learn React, Vue & Angular in 2024!";
       expect(escapeYaml(desc)).toMatch(/^\|/);
     });
+  });
+});
+
+describe("escapeYamlListItem", () => {
+  it("always double-quotes, even for plain strings", () => {
+    expect(escapeYamlListItem("Reading")).toBe('"Reading"');
+  });
+
+  it("escapes embedded double quotes", () => {
+    expect(escapeYamlListItem('Say "Hi"')).toBe('"Say \\"Hi\\""');
+  });
+
+  it("escapes backslashes before quotes are escaped", () => {
+    expect(escapeYamlListItem("C:\\Users")).toBe('"C:\\\\Users"');
+  });
+
+  it("escapes newlines so the scalar stays single-line", () => {
+    expect(escapeYamlListItem("Line1\nLine2")).toBe('"Line1\\nLine2"');
+    expect(escapeYamlListItem("CRLF\r\nhere")).toBe('"CRLF\\nhere"');
+  });
+
+  it("escapes tabs", () => {
+    expect(escapeYamlListItem("A\tB")).toBe('"A\\tB"');
+  });
+
+  it("does not contain a raw newline or tab character in its output", () => {
+    const result = escapeYamlListItem("weird\nname\twith\rcontrol\nchars");
+    expect(result).not.toMatch(/[\n\t\r]/);
   });
 });
 

--- a/src/formatting-utils.ts
+++ b/src/formatting-utils.ts
@@ -30,12 +30,19 @@ export function escapeYaml(str: string | null | undefined): string {
 /**
  * Escapes a string for use as a single-line YAML list item (e.g. a tag or list name),
  * always double-quoting so characters like ':' or '#' can't break the list structure.
+ * Newlines/tabs are escaped to their YAML double-quote escape sequences rather than
+ * left as literal control characters, which would otherwise break the single-line form.
  *
  * @param str - The string to escape
  * @returns A double-quoted YAML scalar safe for inline list use
  */
 export function escapeYamlListItem(str: string): string {
-  return `"${str.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  const escaped = str
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\r\n|\r|\n/g, "\\n")
+    .replace(/\t/g, "\\t");
+  return `"${escaped}"`;
 }
 
 /**

--- a/src/formatting-utils.ts
+++ b/src/formatting-utils.ts
@@ -28,6 +28,17 @@ export function escapeYaml(str: string | null | undefined): string {
 }
 
 /**
+ * Escapes a string for use as a single-line YAML list item (e.g. a tag or list name),
+ * always double-quoting so characters like ':' or '#' can't break the list structure.
+ *
+ * @param str - The string to escape
+ * @returns A double-quoted YAML scalar safe for inline list use
+ */
+export function escapeYamlListItem(str: string): string {
+  return `"${str.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
  * Escapes a path string for use in Markdown links.
  *
  * Wraps paths containing spaces or special characters in angle brackets

--- a/src/hoarder-client.ts
+++ b/src/hoarder-client.ts
@@ -63,6 +63,14 @@ export interface PaginatedBookmarks {
   nextCursor: string | null;
 }
 
+export interface HoarderList {
+  id: string;
+  name: string;
+  icon: string;
+  parentId: string | null;
+  type: "manual" | "smart";
+}
+
 export interface PaginatedHighlights {
   highlights: HoarderHighlight[];
   nextCursor: string | null;
@@ -163,6 +171,33 @@ export class HoarderApiClient {
     } while (cursor);
 
     return allHighlights;
+  }
+
+  async getLists(): Promise<{ lists: HoarderList[] }> {
+    return this.makeRequest<{ lists: HoarderList[] }>("/lists", "GET");
+  }
+
+  async getListBookmarks(
+    listId: string,
+    params?: { limit?: number; cursor?: string }
+  ): Promise<PaginatedBookmarks> {
+    return this.makeRequest<PaginatedBookmarks>(`/lists/${listId}/bookmarks`, "GET", undefined, {
+      ...params,
+      includeContent: false,
+    });
+  }
+
+  async getAllListBookmarkIds(listId: string): Promise<string[]> {
+    const ids: string[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const data = await this.getListBookmarks(listId, { limit: 100, cursor });
+      ids.push(...(data.bookmarks || []).map((b) => b.id));
+      cursor = data.nextCursor || undefined;
+    } while (cursor);
+
+    return ids;
   }
 
   async downloadAsset(

--- a/src/hoarder-client.ts
+++ b/src/hoarder-client.ts
@@ -157,20 +157,12 @@ export class HoarderApiClient {
   }
 
   async getAllHighlights(): Promise<HoarderHighlight[]> {
-    const allHighlights: HoarderHighlight[] = [];
-    let cursor: string | undefined;
-
-    do {
-      const data = await this.getHighlights({
-        limit: 100,
-        cursor: cursor || undefined,
-      });
-
-      allHighlights.push(...(data.highlights || []));
-      cursor = data.nextCursor || undefined;
-    } while (cursor);
-
-    return allHighlights;
+    return this.collectPaginated((cursor) =>
+      this.getHighlights({ limit: 100, cursor }).then((data) => ({
+        items: data.highlights || [],
+        nextCursor: data.nextCursor,
+      }))
+    );
   }
 
   async getLists(): Promise<{ lists: HoarderList[] }> {
@@ -188,16 +180,27 @@ export class HoarderApiClient {
   }
 
   async getAllListBookmarkIds(listId: string): Promise<string[]> {
-    const ids: string[] = [];
+    return this.collectPaginated((cursor) =>
+      this.getListBookmarks(listId, { limit: 100, cursor }).then((data) => ({
+        items: (data.bookmarks || []).map((b) => b.id),
+        nextCursor: data.nextCursor,
+      }))
+    );
+  }
+
+  private async collectPaginated<T>(
+    fetchPage: (cursor?: string) => Promise<{ items: T[]; nextCursor: string | null }>
+  ): Promise<T[]> {
+    const all: T[] = [];
     let cursor: string | undefined;
 
     do {
-      const data = await this.getListBookmarks(listId, { limit: 100, cursor });
-      ids.push(...(data.bookmarks || []).map((b) => b.id));
-      cursor = data.nextCursor || undefined;
+      const { items, nextCursor } = await fetchPage(cursor);
+      all.push(...items);
+      cursor = nextCursor || undefined;
     } while (cursor);
 
-    return ids;
+    return all;
   }
 
   async downloadAsset(

--- a/src/list-utils.test.ts
+++ b/src/list-utils.test.ts
@@ -1,0 +1,72 @@
+import { HoarderList } from "./hoarder-client";
+import { buildBookmarkListsMap, buildListPaths } from "./list-utils";
+
+function makeList(overrides: Partial<HoarderList> & { id: string; name: string }): HoarderList {
+  return {
+    icon: "📁",
+    parentId: null,
+    type: "manual",
+    ...overrides,
+  };
+}
+
+describe("buildListPaths", () => {
+  it("returns the plain name for top-level lists", () => {
+    const lists = [makeList({ id: "1", name: "Reading" })];
+    expect(buildListPaths(lists)).toEqual(new Map([["1", "Reading"]]));
+  });
+
+  it("joins nested lists with a slash", () => {
+    const lists = [
+      makeList({ id: "1", name: "Reading" }),
+      makeList({ id: "2", name: "Tech", parentId: "1" }),
+      makeList({ id: "3", name: "AI", parentId: "2" }),
+    ];
+    const paths = buildListPaths(lists);
+    expect(paths.get("1")).toBe("Reading");
+    expect(paths.get("2")).toBe("Reading/Tech");
+    expect(paths.get("3")).toBe("Reading/Tech/AI");
+  });
+
+  it("falls back to the list name when parentId points to a missing list", () => {
+    const lists = [makeList({ id: "1", name: "Orphan", parentId: "missing" })];
+    expect(buildListPaths(lists).get("1")).toBe("Orphan");
+  });
+
+  it("does not infinite-loop on a cyclical parentId chain", () => {
+    const lists = [
+      makeList({ id: "1", name: "A", parentId: "2" }),
+      makeList({ id: "2", name: "B", parentId: "1" }),
+    ];
+    const paths = buildListPaths(lists);
+    expect(paths.get("1")).toBeDefined();
+    expect(paths.get("2")).toBeDefined();
+  });
+});
+
+describe("buildBookmarkListsMap", () => {
+  it("maps bookmark ids to the paths of every list containing them", async () => {
+    const lists = [
+      makeList({ id: "1", name: "Reading" }),
+      makeList({ id: "2", name: "Tech", parentId: "1" }),
+    ];
+    const bookmarksByList: Record<string, string[]> = {
+      "1": ["bm-a", "bm-b"],
+      "2": ["bm-a"],
+    };
+
+    const result = await buildBookmarkListsMap(
+      lists,
+      async (listId) => bookmarksByList[listId] || []
+    );
+
+    expect(result.get("bm-a")).toEqual(["Reading", "Reading/Tech"]);
+    expect(result.get("bm-b")).toEqual(["Reading"]);
+    expect(result.has("bm-c")).toBe(false);
+  });
+
+  it("returns an empty map when there are no lists", async () => {
+    const result = await buildBookmarkListsMap([], async () => []);
+    expect(result.size).toBe(0);
+  });
+});

--- a/src/list-utils.test.ts
+++ b/src/list-utils.test.ts
@@ -33,14 +33,14 @@ describe("buildListPaths", () => {
     expect(buildListPaths(lists).get("1")).toBe("Orphan");
   });
 
-  it("does not infinite-loop on a cyclical parentId chain", () => {
+  it("falls back to each list's own name on a cyclical parentId chain", () => {
     const lists = [
       makeList({ id: "1", name: "A", parentId: "2" }),
       makeList({ id: "2", name: "B", parentId: "1" }),
     ];
     const paths = buildListPaths(lists);
-    expect(paths.get("1")).toBeDefined();
-    expect(paths.get("2")).toBeDefined();
+    expect(paths.get("1")).toBe("A");
+    expect(paths.get("2")).toBe("B");
   });
 });
 

--- a/src/list-utils.ts
+++ b/src/list-utils.ts
@@ -1,0 +1,63 @@
+import { HoarderList } from "./hoarder-client";
+
+/**
+ * Resolves each list's full nested path (e.g. "Reading/Tech") by walking parentId chains.
+ * Cycles (which shouldn't happen, but the API doesn't guarantee it) fall back to the list's own name.
+ */
+export function buildListPaths(lists: HoarderList[]): Map<string, string> {
+  const byId = new Map(lists.map((list) => [list.id, list]));
+  const paths = new Map<string, string>();
+
+  function resolve(id: string, seen: Set<string>): string {
+    const cached = paths.get(id);
+    if (cached !== undefined) return cached;
+
+    const list = byId.get(id);
+    if (!list) return "";
+
+    if (seen.has(id)) return list.name;
+    seen.add(id);
+
+    const path =
+      list.parentId && byId.has(list.parentId)
+        ? `${resolve(list.parentId, seen)}/${list.name}`
+        : list.name;
+
+    paths.set(id, path);
+    return path;
+  }
+
+  for (const list of lists) {
+    resolve(list.id, new Set());
+  }
+
+  return paths;
+}
+
+/**
+ * Builds a bookmarkId -> list path[] map by paginating each list's bookmarks once.
+ * This is far cheaper than querying list membership per-bookmark: list count is
+ * typically orders of magnitude smaller than bookmark count.
+ */
+export async function buildBookmarkListsMap(
+  lists: HoarderList[],
+  getListBookmarkIds: (listId: string) => Promise<string[]>
+): Promise<Map<string, string[]>> {
+  const listPaths = buildListPaths(lists);
+  const bookmarkLists = new Map<string, string[]>();
+
+  for (const list of lists) {
+    const path = listPaths.get(list.id);
+    if (!path) continue;
+
+    const bookmarkIds = await getListBookmarkIds(list.id);
+    for (const bookmarkId of bookmarkIds) {
+      if (!bookmarkLists.has(bookmarkId)) {
+        bookmarkLists.set(bookmarkId, []);
+      }
+      bookmarkLists.get(bookmarkId)!.push(path);
+    }
+  }
+
+  return bookmarkLists;
+}

--- a/src/list-utils.ts
+++ b/src/list-utils.ts
@@ -44,13 +44,19 @@ export async function buildBookmarkListsMap(
   getListBookmarkIds: (listId: string) => Promise<string[]>
 ): Promise<Map<string, string[]>> {
   const listPaths = buildListPaths(lists);
+
+  // Fetch each list's bookmarks concurrently (lists are independent), but merge
+  // afterward in list order so a bookmark's `lists` array is deterministic
+  // regardless of which network request happens to finish first.
+  const perList = await Promise.all(
+    lists.map(async (list) => ({
+      path: listPaths.get(list.id)!,
+      bookmarkIds: await getListBookmarkIds(list.id),
+    }))
+  );
+
   const bookmarkLists = new Map<string, string[]>();
-
-  for (const list of lists) {
-    const path = listPaths.get(list.id);
-    if (!path) continue;
-
-    const bookmarkIds = await getListBookmarkIds(list.id);
+  for (const { path, bookmarkIds } of perList) {
     for (const bookmarkId of bookmarkIds) {
       if (!bookmarkLists.has(bookmarkId)) {
         bookmarkLists.set(bookmarkId, []);

--- a/src/list-utils.ts
+++ b/src/list-utils.ts
@@ -8,27 +8,26 @@ export function buildListPaths(lists: HoarderList[]): Map<string, string> {
   const byId = new Map(lists.map((list) => [list.id, list]));
   const paths = new Map<string, string>();
 
-  function resolve(id: string, seen: Set<string>): string {
-    const cached = paths.get(id);
-    if (cached !== undefined) return cached;
-
-    const list = byId.get(id);
-    if (!list) return "";
-
-    if (seen.has(id)) return list.name;
-    seen.add(id);
-
-    const path =
-      list.parentId && byId.has(list.parentId)
-        ? `${resolve(list.parentId, seen)}/${list.name}`
-        : list.name;
-
-    paths.set(id, path);
-    return path;
-  }
-
   for (const list of lists) {
-    resolve(list.id, new Set());
+    const chain = [list.name];
+    const visited = new Set<string>([list.id]);
+    let parentId = list.parentId;
+    let hasCycle = false;
+
+    while (parentId && byId.has(parentId)) {
+      if (visited.has(parentId)) {
+        hasCycle = true;
+        break;
+      }
+      visited.add(parentId);
+      const parent = byId.get(parentId)!;
+      chain.unshift(parent.name);
+      parentId = parent.parentId;
+    }
+
+    // On a cycle, fall back to just the list's own name rather than a
+    // partial/garbled chain — the ancestor path can't be resolved.
+    paths.set(list.id, hasCycle ? list.name : chain.join("/"));
   }
 
   return paths;

--- a/src/main.ts
+++ b/src/main.ts
@@ -466,8 +466,9 @@ export default class HoarderPlugin extends Plugin {
           const title = getBookmarkTitle(bookmark);
           const fileName = `${folderPath}/${sanitizeFileName(title, bookmark.createdAt)}.md`;
 
-          // Get highlights for this bookmark from pre-fetched map
+          // Get highlights and lists for this bookmark from pre-fetched maps
           const highlights = highlightsByBookmarkId.get(bookmark.id) || [];
+          const lists = bookmarkListsMap.get(bookmark.id);
 
           const fileExists = await this.app.vault.adapter.exists(fileName);
 
@@ -507,7 +508,6 @@ export default class HoarderPlugin extends Plugin {
               }
 
               // Generate new content and compare with existing
-              const lists = bookmarkListsMap.get(bookmark.id);
               const newContent = await this.formatBookmarkAsMarkdown(
                 bookmark,
                 title,
@@ -526,7 +526,6 @@ export default class HoarderPlugin extends Plugin {
               }
             }
           } else {
-            const lists = bookmarkListsMap.get(bookmark.id);
             const content = await this.formatBookmarkAsMarkdown(bookmark, title, highlights, lists);
             await this.app.vault.create(fileName, content);
             totalBookmarks++;

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {
   HoarderHighlight,
   PaginatedBookmarks,
 } from "./hoarder-client";
+import { buildBookmarkListsMap } from "./list-utils";
 import { contentHasChanged, extractNotesSection } from "./markdown-utils";
 import { SyncStats, buildSyncMessage } from "./message-utils";
 import { shouldPushLocalNotesToRemote } from "./note-sync-utils";
@@ -407,6 +408,22 @@ export default class HoarderPlugin extends Plugin {
         }
       }
 
+      // Fetch list membership in bulk if enabled. Iterating lists (cheap, few per user)
+      // and paginating each list's bookmarks is far cheaper than querying per-bookmark
+      // list membership, since bookmark counts are typically much larger than list counts.
+      let bookmarkListsMap = new Map<string, string[]>();
+      if (this.settings.syncLists && this.client) {
+        try {
+          const { lists } = await this.client.getLists();
+          bookmarkListsMap = await buildBookmarkListsMap(lists, (listId) =>
+            this.client!.getAllListBookmarkIds(listId)
+          );
+        } catch (error) {
+          console.error("Error fetching lists in bulk:", error);
+          // Continue without lists rather than failing the entire sync
+        }
+      }
+
       let cursor: string | undefined;
 
       do {
@@ -490,7 +507,13 @@ export default class HoarderPlugin extends Plugin {
               }
 
               // Generate new content and compare with existing
-              const newContent = await this.formatBookmarkAsMarkdown(bookmark, title, highlights);
+              const lists = bookmarkListsMap.get(bookmark.id);
+              const newContent = await this.formatBookmarkAsMarkdown(
+                bookmark,
+                title,
+                highlights,
+                lists
+              );
               const existingContent = await this.app.vault.adapter.read(fileName);
 
               if (contentHasChanged(existingContent, newContent)) {
@@ -503,7 +526,8 @@ export default class HoarderPlugin extends Plugin {
               }
             }
           } else {
-            const content = await this.formatBookmarkAsMarkdown(bookmark, title, highlights);
+            const lists = bookmarkListsMap.get(bookmark.id);
+            const content = await this.formatBookmarkAsMarkdown(bookmark, title, highlights, lists);
             await this.app.vault.create(fileName, content);
             totalBookmarks++;
           }
@@ -552,7 +576,8 @@ export default class HoarderPlugin extends Plugin {
   async formatBookmarkAsMarkdown(
     bookmark: HoarderBookmark,
     title: string,
-    highlights?: HoarderHighlight[]
+    highlights?: HoarderHighlight[],
+    lists?: string[]
   ): Promise<string> {
     const { content: assetContent, frontmatter: assetsFm } = await processBookmarkAssets(
       this.app,
@@ -568,7 +593,8 @@ export default class HoarderPlugin extends Plugin {
       highlights,
       assetContent,
       assetsFm,
-      this.settings
+      this.settings,
+      lists
     );
 
     const template =

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,13 @@
 import { EditorView } from "@codemirror/view";
-import { AbstractInputSuggest, App, ButtonComponent, Notice, PluginSettingTab, Setting, TFolder } from "obsidian";
+import {
+  AbstractInputSuggest,
+  App,
+  ButtonComponent,
+  Notice,
+  PluginSettingTab,
+  Setting,
+  TFolder,
+} from "obsidian";
 
 import HoarderPlugin from "./main";
 import { createTemplateEditor, setEditorValue } from "./template-editor";
@@ -17,6 +25,7 @@ export interface HoarderSettings {
   onlyFavorites: boolean;
   syncNotesToHoarder: boolean;
   syncHighlights: boolean;
+  syncLists: boolean;
   onlyBookmarksWithHighlights: boolean;
   excludedTags: string[];
   includedTags: string[];
@@ -50,6 +59,7 @@ export const DEFAULT_SETTINGS: HoarderSettings = {
   onlyFavorites: false,
   syncNotesToHoarder: true,
   syncHighlights: true,
+  syncLists: false,
   onlyBookmarksWithHighlights: false,
   excludedTags: [],
   includedTags: [],
@@ -289,6 +299,18 @@ export class HoarderSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Sync lists")
+      .setDesc(
+        "Include the Karakeep list(s) each bookmark belongs to as a 'lists' frontmatter field. Nested lists are rendered as slash-separated paths (e.g. 'Reading/Tech')."
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.syncLists).onChange(async (value) => {
+          this.plugin.settings.syncLists = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
       .setName("Download assets")
       .setDesc(
         "Download images and other assets locally (if disabled, assets will be embedded using their source URLs)"
@@ -400,6 +422,7 @@ export class HoarderSettingTab extends PluginSettingTab {
       addVarLine(refContent, ["it.content_type"], '("link", "text", "asset")');
       addVarLine(refContent, ["it.content_html", "it.author", "it.archived", "it.favourited"]);
       addVarLine(refContent, ["it.tags"], "(string array)");
+      addVarLine(refContent, ["it.lists"], "(string array, nested paths e.g. 'Reading/Tech')");
       addVarLine(refContent, ["it.hoarder_url", "it.visit_link"]);
 
       refContent.createEl("br");
@@ -410,7 +433,11 @@ export class HoarderSettingTab extends PluginSettingTab {
       refContent.createEl("strong", { text: "Assets" });
       addVarLine(refContent, ["it.assets.content"], "(rendered embeds)");
       addVarLine(refContent, ["it.assets.banner", "it.assets.screenshot", "it.assets.image"]);
-      addVarLine(refContent, ["it.assets.full_page_archive", "it.assets.pdf_archive", "it.assets.video"]);
+      addVarLine(refContent, [
+        "it.assets.full_page_archive",
+        "it.assets.pdf_archive",
+        "it.assets.video",
+      ]);
       addVarLine(refContent, ["it.assets.additional"], "(string array)");
 
       refContent.createEl("br");
@@ -422,7 +449,11 @@ export class HoarderSettingTab extends PluginSettingTab {
 
       refContent.createEl("br");
       refContent.createEl("strong", { text: "Helper functions" });
-      addVarLine(refContent, ["it.escapeYaml(str)", "it.escapeMarkdownPath(str)", "it.formatDate(iso)"]);
+      addVarLine(refContent, [
+        "it.escapeYaml(str)",
+        "it.escapeMarkdownPath(str)",
+        "it.formatDate(iso)",
+      ]);
 
       const editorContainer = containerEl.createDiv({ cls: "hoarder-template-editor" });
 

--- a/src/tag-utils.test.ts
+++ b/src/tag-utils.test.ts
@@ -127,10 +127,29 @@ describe("sanitizeTag", () => {
       expect(sanitizeTag(longTag)).toBe(longTag);
     });
 
-    it("should preserve Unicode letters but remove emoji and symbols", () => {
-      expect(sanitizeTag("tag🚀emoji")).toBe("tagemoji");
+    it("should preserve Unicode letters and accents", () => {
       expect(sanitizeTag("café")).toBe("café");
       expect(sanitizeTag("日本語")).toBe("日本語");
+    });
+
+    it("should preserve emoji and dingbats, per Obsidian's actual tag support", () => {
+      // https://obsidian.md/help/tags: tags allow "commonly accepted Unicode
+      // characters, including emojis and other symbols" (e.g. dingbats).
+      expect(sanitizeTag("tag🚀emoji")).toBe("tag🚀emoji");
+      expect(sanitizeTag("tag❋dingbat")).toBe("tag❋dingbat");
+      expect(sanitizeTag("⭐starred")).toBe("⭐starred");
+    });
+
+    it("should keep multi-codepoint emoji sequences intact", () => {
+      expect(sanitizeTag("👨‍👩‍👧‍👦family")).toBe("👨‍👩‍👧‍👦family");
+      expect(sanitizeTag("🇺🇸flag")).toBe("🇺🇸flag");
+      expect(sanitizeTag("👍🏽thumb")).toBe("👍🏽thumb");
+    });
+
+    it("should still strip currency and math symbols, which Obsidian does not accept", () => {
+      expect(sanitizeTag("tag$money")).toBe("tagmoney");
+      expect(sanitizeTag("tag+plus")).toBe("tagplus");
+      expect(sanitizeTag("tag=equals")).toBe("tagequals");
     });
 
     it("should preserve Chinese (CJK) tags", () => {

--- a/src/tag-utils.ts
+++ b/src/tag-utils.ts
@@ -1,9 +1,23 @@
+// Characters allowed in an Obsidian tag beyond \p{L}/\p{N}/_/-//.
+// Obsidian's docs (https://obsidian.md/help/tags) say tags also allow "commonly
+// accepted Unicode characters, including emojis and other symbols" — confirmed by
+// real-world behavior (e.g. dingbats and emoji render as valid tags) even though
+// Obsidian doesn't publish an exact spec. \p{So} (Symbol, Other) covers emoji and
+// dingbats while excluding currency/math symbols like $, +, = that aren't accepted.
+// The remaining code points are the joiners/modifiers needed to keep multi-codepoint
+// emoji sequences (flags, skin tones, ZWJ families, keycaps) intact after filtering.
+const EMOJI_JOINERS = "‍️⃣"; // ZWJ, variation selector-16, keycap combiner
+const ALLOWED_TAG_CHARS = new RegExp(
+  `[^\\p{L}\\p{N}_\\-/\\p{So}\\p{Extended_Pictographic}\\p{Emoji_Modifier}\\p{Regional_Indicator}${EMOJI_JOINERS}]`,
+  "gu"
+);
+
 /**
  * Sanitizes a tag string to conform to Obsidian's tag requirements.
  *
  * Obsidian tag rules:
  * - Allowed characters: Unicode letters (including CJK/Chinese/Japanese/Korean),
- *   numbers, underscore (_), hyphen (-), forward slash (/)
+ *   numbers, underscore (_), hyphen (-), forward slash (/), and emoji/symbols
  * - Must contain at least one non-numerical character
  * - No blank spaces (converted to hyphens)
  * - Case-insensitive
@@ -21,11 +35,8 @@ export function sanitizeTag(tag: string): string | null {
   // Replace spaces with hyphens (kebab-case)
   sanitized = sanitized.replace(/\s+/g, "-");
 
-  // Remove any characters that aren't Unicode letters (including CJK), numbers,
-  // underscore, hyphen, or forward slash.
-  // \p{L} matches any Unicode letter (Latin, CJK, Cyrillic, Arabic, etc.)
-  // \p{N} matches any Unicode number
-  sanitized = sanitized.replace(/[^\p{L}\p{N}_\-/]/gu, "");
+  // Remove any character not in Obsidian's allowed set (see ALLOWED_TAG_CHARS above).
+  sanitized = sanitized.replace(ALLOWED_TAG_CHARS, "");
 
   // Return null if after sanitization we have an empty string
   if (!sanitized) return null;

--- a/src/template-renderer.test.ts
+++ b/src/template-renderer.test.ts
@@ -526,4 +526,16 @@ describe("lists in template context", () => {
     const result = renderTemplate(DEFAULT_TEMPLATE, context);
     expect(result).toContain('- "Say \\"Hi\\""');
   });
+
+  it("escapes newlines and tabs inside list names so the YAML scalar stays single-line", () => {
+    const bookmark = makeBookmark();
+    const context = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings(), [
+      "Weird\nName\tHere",
+    ]);
+    const result = renderTemplate(DEFAULT_TEMPLATE, context);
+    expect(result).toContain('- "Weird\\nName\\tHere"');
+    // The rendered frontmatter must not contain an actual raw newline/tab inside the list item.
+    const listsLine = result.split("\n").find((line) => line.trim().startsWith("- ") && line.includes("Weird"));
+    expect(listsLine).toBeDefined();
+  });
 });

--- a/src/template-renderer.test.ts
+++ b/src/template-renderer.test.ts
@@ -3,7 +3,7 @@ import { escapeMarkdownPath, escapeYaml } from "./formatting-utils";
 import { HoarderBookmark, HoarderHighlight } from "./hoarder-client";
 import { DEFAULT_SETTINGS, HoarderSettings } from "./settings";
 import { sanitizeTags } from "./tag-utils";
-import { NOTE_BLOCK_START, NOTE_BLOCK_END } from "./template-renderer";
+import { NOTE_BLOCK_END, NOTE_BLOCK_START } from "./template-renderer";
 import {
   DEFAULT_TEMPLATE,
   buildTemplateContext,
@@ -389,9 +389,7 @@ describe("buildTemplateContext", () => {
     const bookmark = makeBookmark({ note: "My editable note" });
     const ctx = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings());
     expect(ctx.note).toBe("My editable note");
-    expect(ctx.noteBlock).toBe(
-      `${NOTE_BLOCK_START}\nMy editable note\n${NOTE_BLOCK_END}`
-    );
+    expect(ctx.noteBlock).toBe(`${NOTE_BLOCK_START}\nMy editable note\n${NOTE_BLOCK_END}`);
   });
 
   it("should handle empty note in noteBlock", () => {
@@ -437,34 +435,22 @@ describe("validateTemplate", () => {
     const result = validateTemplate("---\ntitle: test\n---\n# Test");
     expect(result.valid).toBe(true);
     expect(result.warnings).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("bookmark_id"),
-      ])
+      expect.arrayContaining([expect.stringContaining("bookmark_id")])
     );
   });
 
   it("should warn when original_note is missing", () => {
-    const result = validateTemplate(
-      "---\nbookmark_id: test\n---\n# Test\n\n## Notes\n\ntest"
-    );
+    const result = validateTemplate("---\nbookmark_id: test\n---\n# Test\n\n## Notes\n\ntest");
     expect(result.valid).toBe(true);
     expect(result.warnings).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("original_note"),
-      ])
+      expect.arrayContaining([expect.stringContaining("original_note")])
     );
   });
 
   it("should warn when Notes section is missing", () => {
-    const result = validateTemplate(
-      "---\nbookmark_id: test\noriginal_note: test\n---\n# Test"
-    );
+    const result = validateTemplate("---\nbookmark_id: test\noriginal_note: test\n---\n# Test");
     expect(result.valid).toBe(true);
-    expect(result.warnings).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("## Notes"),
-      ])
-    );
+    expect(result.warnings).toEqual(expect.arrayContaining([expect.stringContaining("## Notes")]));
   });
 });
 
@@ -498,5 +484,46 @@ describe("custom template", () => {
     const template = `<%= it.escapeYaml("value: with colons") %>`;
     const result = renderTemplate(template, context);
     expect(result).toContain("value");
+  });
+});
+
+describe("lists in template context", () => {
+  it("defaults to an empty array when no lists are passed", () => {
+    const context = buildTemplateContext(makeBookmark(), "Test", [], "", null, makeSettings());
+    expect(context.lists).toEqual([]);
+  });
+
+  it("passes through the given list paths", () => {
+    const context = buildTemplateContext(makeBookmark(), "Test", [], "", null, makeSettings(), [
+      "Reading",
+      "Reading/Tech",
+    ]);
+    expect(context.lists).toEqual(["Reading", "Reading/Tech"]);
+  });
+
+  it("renders lists as a quoted YAML frontmatter array in the default template", () => {
+    const bookmark = makeBookmark();
+    const context = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings(), [
+      "Reading",
+      "Reading/Tech",
+    ]);
+    const result = renderTemplate(DEFAULT_TEMPLATE, context);
+    expect(result).toContain('lists:\n  - "Reading"\n  - "Reading/Tech"\n');
+  });
+
+  it("omits the lists frontmatter key entirely when there are none", () => {
+    const bookmark = makeBookmark();
+    const context = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings());
+    const result = renderTemplate(DEFAULT_TEMPLATE, context);
+    expect(result).not.toContain("lists:");
+  });
+
+  it("escapes quotes inside list names via escapeYamlListItem", () => {
+    const bookmark = makeBookmark();
+    const context = buildTemplateContext(bookmark, "Test", [], "", null, makeSettings(), [
+      'Say "Hi"',
+    ]);
+    const result = renderTemplate(DEFAULT_TEMPLATE, context);
+    expect(result).toContain('- "Say \\"Hi\\""');
   });
 });

--- a/src/template-renderer.ts
+++ b/src/template-renderer.ts
@@ -1,7 +1,12 @@
 import { Eta } from "eta";
 
 import { AssetFrontmatter } from "./asset-handler";
-import { escapeMarkdownPath, escapeYaml, sanitizeHtml } from "./formatting-utils";
+import {
+  escapeMarkdownPath,
+  escapeYaml,
+  escapeYamlListItem,
+  sanitizeHtml,
+} from "./formatting-utils";
 import { HoarderBookmark, HoarderHighlight } from "./hoarder-client";
 import { HoarderSettings } from "./settings";
 import { sanitizeTags } from "./tag-utils";
@@ -22,6 +27,7 @@ export interface TemplateContext {
   content_html: string | undefined | null;
   author: string | undefined | null;
   tags: string[];
+  lists: string[];
   yaml: {
     url: string;
     title: string;
@@ -50,6 +56,7 @@ export interface TemplateContext {
   visit_link: string | null;
   sync_highlights: boolean;
   escapeYaml: (str: string | null | undefined) => string;
+  escapeYamlListItem: (str: string) => string;
   escapeMarkdownPath: (path: string) => string;
   formatDate: (iso: string) => string;
 }
@@ -64,6 +71,8 @@ date: <%= it.created_at %>
 <% if (it.modified_at) { %>modified: <%= it.modified_at %>
 <% } %><% if (it.tags.length > 0) { %>tags:
 <% it.tags.forEach(function(tag) { %>  - <%= tag %>
+<% }) %><% } %><% if (it.lists.length > 0) { %>lists:
+<% it.lists.forEach(function(list) { %>  - <%= it.escapeYamlListItem(list) %>
 <% }) %><% } %>note: <%= it.yaml.note %>
 original_note: <%= it.yaml.note %>
 summary: <%= it.yaml.summary %>
@@ -139,7 +148,8 @@ export function buildTemplateContext(
   highlights: HoarderHighlight[] | undefined,
   assetContent: string,
   assetsFm: AssetFrontmatter | null,
-  settings: HoarderSettings
+  settings: HoarderSettings,
+  lists: string[] = []
 ): TemplateContext {
   const url = bookmark.content.type === "link" ? bookmark.content.url : bookmark.content.sourceUrl;
   const description =
@@ -171,6 +181,7 @@ export function buildTemplateContext(
     content_html: bookmark.content.htmlContent ? sanitizeHtml(bookmark.content.htmlContent) : null,
     author: bookmark.content.author ?? null,
     tags,
+    lists,
     yaml: {
       url: escapeYaml(url),
       title: escapeYaml(title),
@@ -199,6 +210,7 @@ export function buildTemplateContext(
     visit_link: url && bookmark.content.type !== "asset" ? escapeMarkdownPath(url) : null,
     sync_highlights: settings.syncHighlights,
     escapeYaml,
+    escapeYamlListItem,
     escapeMarkdownPath,
     formatDate: formatHighlightDate,
   };
@@ -235,6 +247,7 @@ const SAMPLE_CONTEXT: TemplateContext = {
   content_html: null,
   author: "Sample Author",
   tags: ["sample-tag"],
+  lists: ["Sample List"],
   yaml: {
     url: "https://example.com",
     title: "Sample Bookmark",
@@ -256,18 +269,24 @@ const SAMPLE_CONTEXT: TemplateContext = {
   visit_link: "https://example.com",
   sync_highlights: true,
   escapeYaml,
+  escapeYamlListItem,
   escapeMarkdownPath,
   formatDate: formatHighlightDate,
 };
 
-export function validateTemplate(
-  templateString: string
-): { valid: boolean; error?: string; warnings?: string[] } {
+export function validateTemplate(templateString: string): {
+  valid: boolean;
+  error?: string;
+  warnings?: string[];
+} {
   // 1. Check syntax (compilation)
   try {
     eta.compile(templateString);
   } catch (error: unknown) {
-    return { valid: false, error: `Syntax error: ${error instanceof Error ? error.message : String(error)}` };
+    return {
+      valid: false,
+      error: `Syntax error: ${error instanceof Error ? error.message : String(error)}`,
+    };
   }
 
   // 2. Test render with sample data
@@ -275,7 +294,10 @@ export function validateTemplate(
   try {
     rendered = renderTemplate(templateString, SAMPLE_CONTEXT);
   } catch (error: unknown) {
-    return { valid: false, error: `Render error: ${error instanceof Error ? error.message : String(error)}` };
+    return {
+      valid: false,
+      error: `Render error: ${error instanceof Error ? error.message : String(error)}`,
+    };
   }
 
   // 3. Check output structure
@@ -290,13 +312,13 @@ export function validateTemplate(
   }
 
   if (!rendered.includes("original_note:")) {
-    warnings.push(
-      "Template output is missing original_note — bi-directional sync will not work"
-    );
+    warnings.push("Template output is missing original_note — bi-directional sync will not work");
   }
 
   if (!/## Notes\b/.test(rendered)) {
-    warnings.push("Template output is missing ## Notes section — bi-directional sync will not work");
+    warnings.push(
+      "Template output is missing ## Notes section — bi-directional sync will not work"
+    );
   }
 
   return { valid: true, warnings: warnings.length > 0 ? warnings : undefined };


### PR DESCRIPTION
## Summary
- Closes #47 by adding an opt-in "Sync lists" setting that includes each bookmark's Karakeep list membership as a `lists` frontmatter field, e.g.:
  ```yaml
  lists:
    - "Reading"
    - "Reading/Tech"
  ```
- Nested lists (via the API's `parentId`) are resolved into slash-separated paths.
- Performance: fetches `GET /lists` once, then paginates `GET /lists/{listId}/bookmarks` per list to build a bookmark→list map — list count is typically far smaller than bookmark count, so this scales with list count rather than bookmark count (avoids N calls to `GET /bookmarks/{id}/lists`).
- Off by default since it adds API calls; exposed to custom templates as `it.lists` and `it.escapeYamlListItem(...)`.

## Test plan
- [x] `npm test` (475 tests passing, including new `list-utils.test.ts` and new `template-renderer.test.ts` cases for list rendering/escaping)
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Verified against a live Karakeep instance (hoarder.hofker.org, 7 lists incl. one genuinely nested list, 296 bookmarks): `GET /lists` response matches the assumed schema exactly (`id`, `name`, `icon`, `parentId`, `type`, `query`), and the actual `HoarderApiClient` + `list-utils.ts` modules (compiled and run directly, not reimplemented) correctly resolved `"Books/Kids Books"` as a nested path and built a correct bookmark→list map in ~1.1s for the 7-list account.

Note from live testing: Karakeep does not auto-propagate membership from a nested list to its parent — a bookmark in "Kids Books" is not automatically considered a member of "Books" unless explicitly added to both. The plugin's output reflects that (each bookmark gets exactly the list paths it's actually a member of).